### PR TITLE
Fix invalid value for '--attach' / '-a' error

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -88,7 +88,7 @@ pass_runtime = click.make_pass_decorator(Runtime)
 #
 @cli.command("remove-bugs", short_help="Remove provided BUGS from ADVISORY")
 @click.option('--advisory', '-a', 'advisory',
-              default=False, metavar='ADVISORY',
+              type=int, metavar='ADVISORY',
               help='Remove found bugs from ADVISORY')
 @use_default_advisory_option
 @click.option("--id", metavar='BUGID', default=[],
@@ -126,7 +126,7 @@ def remove_bugs(runtime, advisory, default_advisory_type, id):
     if default_advisory_type is not None:
         advisory = find_default_advisory(runtime, default_advisory_type)
 
-    if advisory is not False:
+    if advisory:
         try:
             advs = Erratum(errata_id=advisory)
         except GSSError:
@@ -239,7 +239,7 @@ Fields for the short format: Release date, State, Synopsys, URL
 #
 @cli.command("repair-bugs", short_help="Move bugs attached to ADVISORY from one state to another")
 @click.option("--advisory", "-a",
-              metavar='ADVISORY',
+              type=int, metavar='ADVISORY',
               help="Repair bugs attached to ADVISORY.")
 @click.option("--auto",
               required=False,
@@ -577,7 +577,7 @@ written out to summary_results.json.
               default=15, type=int,
               help="How long to poll before quitting")
 @click.option("--advisory", "-a",
-              metavar='ADVISORY',
+              type=int, metavar='ADVISORY',
               help="Advisory to watch")
 @use_default_advisory_option
 @click.option("--noop", "--dry-run",

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -7,7 +7,7 @@ from elliottlib.cli.common import cli, use_default_advisory_option, find_default
 @cli.command('attach-cve-flaws',
              short_help='Attach corresponding flaw bugs for trackers in advisory (first-fix only)')
 @click.option('--advisory', '-a', 'advisory_id',
-              default=False,
+              type=int,
               help='Find tracker bugs in given advisory')
 @click.option("--noop", "--dry-run",
               required=False,
@@ -33,6 +33,8 @@ def attach_cve_flaws_cli(runtime, advisory_id, noop, default_advisory_type):
     1851422, 1866148, 1858981, 1852331, 1861044, 1857081, 1857977, 1848647,
     1849044, 1856529, 1843575, 1840253]
     """
+    if sum(map(bool, [advisory_id, default_advisory_type])) != 1:
+        raise click.BadParameter("Use one of --use-default-advisory or --advisory")
     runtime.initialize()
     bzurl = runtime.gitdata.bz_server_url()
     bzapi = bugzilla.Bugzilla(bzurl)

--- a/elliottlib/cli/create_placeholder_cli.py
+++ b/elliottlib/cli/create_placeholder_cli.py
@@ -31,7 +31,7 @@ pass_runtime = click.make_pass_decorator(Runtime)
               help='KIND [{}] of placeholder bug to create. Affects BZ title.'.format(
                   ', '.join(elliottlib.constants.standard_advisory_types)))
 @click.option('--attach', '-a', 'advisory',
-              default=False, metavar='ADVISORY',
+              type=int, metavar='ADVISORY',
               help='Attach the bug to ADVISORY')
 @use_default_advisory_option
 @pass_runtime
@@ -43,11 +43,11 @@ def create_placeholder_cli(runtime, kind, advisory, default_advisory_type):
 
     $ elliott --group openshift-4.1 create-placeholder --kind rpm --attach 12345
 """.format('/'.join(elliottlib.constants.standard_advisory_types))
-
-    runtime.initialize()
     if advisory and default_advisory_type:
         raise click.BadParameter(
             "Use only one of --use-default-advisory or --advisory")
+
+    runtime.initialize()
 
     if default_advisory_type is not None:
         advisory = find_default_advisory(runtime, default_advisory_type)
@@ -63,7 +63,7 @@ def create_placeholder_cli(runtime, kind, advisory, default_advisory_type):
 
     click.echo("Created BZ: {} {}".format(newbug.id, newbug.weburl))
 
-    if advisory is not False:
+    if advisory:
         click.echo("Attaching to advisory...")
 
         try:

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -22,7 +22,7 @@ pass_runtime = click.make_pass_decorator(Runtime)
 
 @cli.command("find-bugs", short_help="Find or add MODIFED/VERIFIED bugs to ADVISORY")
 @click.option("--add", "-a", 'advisory',
-              default=False, metavar='ADVISORY',
+              type=int, metavar='ADVISORY',
               help="Add found bugs to ADVISORY. Applies to bug flags as well (by default only a list of discovered bugs are displayed)")
 @use_default_advisory_option
 @click.option("--mode",

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -36,7 +36,7 @@ pass_runtime = click.make_pass_decorator(Runtime)
 @cli.command('find-builds', short_help='Find or attach builds to ADVISORY')
 @click.option(
     '--attach', '-a', 'advisory',
-    default=False, metavar='ADVISORY',
+    type=int, metavar='ADVISORY',
     help='Attach the builds to ADVISORY (by default only a list of builds are displayed)')
 @use_default_advisory_option
 @click.option(


### PR DESCRIPTION
A recent click change results in the following error:

```sh
$ elliott -g openshift-4.8 create-placeholder --kind rpm -a 68847
Usage: elliott create-placeholder [OPTIONS]
Try 'elliott create-placeholder -h' for help.

Error: Invalid value for '--attach' / '-a': '68847' is not a valid boolean.
```

Let's specify `type=int` for all `advisory` options and use `None` as
the default value.