### PR TITLE
Fix golang-builder cve check

### DIFF
--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -274,7 +274,7 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int], ma
             break
         attached_builds = errata.get_advisory_nvrs(advisory_id_map[kind])
         packages = list(attached_builds.keys())
-        if type == 'image':
+        if kind == 'image':
             packages.extend(constants.SPECIAL_CVE_COMPONENTS)
 
         for bug in tracker_bugs:


### PR DESCRIPTION
Fixing a bug in https://github.com/openshift/elliott/pull/458/files

Test
`elliott -g openshift-4.11 --assembly 4.11.14 find-bugs:sweep --check-builds --into-default-advisories --dry-run`