### PR TITLE
ART-6236: find-bugs:sweep: Add --cve-only option

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -360,6 +360,9 @@ class BugTracker:
     def blocker_search(self, status, search_filter, verbose=False, **kwargs):
         raise NotImplementedError
 
+    def cve_tracker_search(self, status, search_filter, verbose=False, **kwargs):
+        raise NotImplementedError
+
     def get_bug(self, bugid, **kwargs):
         raise NotImplementedError
 
@@ -665,6 +668,14 @@ class JIRABugTracker(BugTracker):
         )
         return self._search(query, verbose=verbose)
 
+    def cve_tracker_search(self, status, search_filter='default', verbose=False):
+        query = self._query(
+            status=status,
+            search_filter=search_filter,
+            include_labels=["SecurityTracking"],
+        )
+        return self._search(query, verbose=verbose)
+
     def remove_bugs(self, advisory_obj, bugids: List, noop=False):
         if noop:
             print(f"Would've removed bugs: {bugids}")
@@ -764,6 +775,11 @@ class BugzillaBugTracker(BugTracker):
 
     def search(self, status, search_filter='default', verbose=False):
         query = _construct_query_url(self.config, status, search_filter)
+        return self._search(query, verbose)
+
+    def cve_tracker_search(self, status, search_filter='default', verbose=False):
+        query = _construct_query_url(self.config, status, search_filter)
+        query.addKeyword('SecurityTracking')
         return self._search(query, verbose)
 
     def _search(self, query, verbose=False):

--- a/elliottlib/cli/find_bugs_blocker_cli.py
+++ b/elliottlib/cli/find_bugs_blocker_cli.py
@@ -12,7 +12,8 @@ from elliottlib.util import green_prefix
 class FindBugsBlocker(FindBugsMode):
     def __init__(self):
         super().__init__(
-            status={'NEW', 'ASSIGNED', 'POST', 'MODIFIED', 'ON_DEV', 'ON_QA'}
+            status={'NEW', 'ASSIGNED', 'POST', 'MODIFIED', 'ON_DEV', 'ON_QA'},
+            cve_only=False,
         )
 
     def search(self, bug_tracker_obj: BugTracker, verbose: bool = False):

--- a/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliottlib/cli/find_bugs_qe_cli.py
@@ -13,7 +13,8 @@ LOGGER = logutil.getLogger(__name__)
 class FindBugsQE(FindBugsMode):
     def __init__(self):
         super().__init__(
-            status={'MODIFIED'}
+            status={'MODIFIED'},
+            cve_only=False,
         )
 
 

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -109,7 +109,7 @@ async def verify_bugs_cli(runtime, verify_bug_status, output, no_verify_blocking
 
 async def verify_bugs(runtime, verify_bug_status, output, no_verify_blocking_bugs):
     validator = BugValidator(runtime, output)
-    find_bugs_obj = FindBugsSweep()
+    find_bugs_obj = FindBugsSweep(cve_only=False)
     ocp_bugs = []
     logger.info(f'Using {runtime.assembly} assembly to search bugs')
     for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:

--- a/tests/test_find_bugs_sweep_cli.py
+++ b/tests/test_find_bugs_sweep_cli.py
@@ -25,7 +25,7 @@ class TestFindBugsMode(unittest.TestCase):
             'server': "server"
         }
         bug_tracker = BugzillaBugTracker(config)
-        find_bugs = FindBugsMode(status=['foo', 'bar'])
+        find_bugs = FindBugsMode(status=['foo', 'bar'], cve_only=False)
         find_bugs.include_status(['alpha'])
         find_bugs.exclude_status(['foo'])
         bugs = find_bugs.search(bug_tracker_obj=bug_tracker)


### PR DESCRIPTION
This feature is requested by OpenShift QE to find CVE trackers against a release branch.