### PR TITLE
[attach-cve-flaws] Handle missing "package state" when determining first fix

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -1195,6 +1195,11 @@ def is_first_fix_any(flaw_bug: BugzillaBug, tracker_bugs: Iterable[Bug], current
     components_not_yet_fixed = []
     pyxis_base_url = "https://pyxis.engineering.redhat.com/v1/repositories/registry/registry.access.redhat.com" \
                      "/repository/{pkg_name}/images?page_size=1&include=data.brew"
+
+    if 'package_state' not in data:
+        logger.info(f'{flaw_bug.id} ({alias}) not considered a first-fix because no unfixed components were found')
+        return False
+
     for package_info in data['package_state']:
         # previously we were also checking `package_info['fix_state'] in ['Affected', 'Under investigation']`
         # but we don't need to verify that since according to @sfowler if a package has a tracker for a cve

--- a/tests/test_bzutil.py
+++ b/tests/test_bzutil.py
@@ -509,6 +509,18 @@ class TestBZUtil(asynctest.TestCase):
         actual = bzutil.is_first_fix_any(flaw_bug, tracker_bugs, tr)
         self.assertEqual(expected, actual)
 
+    def test_is_first_fix_any_missing_package_state(self):
+        hydra_data = {}
+        flexmock(requests).should_receive('get')\
+            .and_return(flexmock(json=lambda: hydra_data, raise_for_status=lambda: None))\
+
+        tr = '4.8.0'
+        flaw_bug = BugzillaBug(flexmock(id=1, alias=['CVE-123']))
+        tracker_bugs = [flexmock(id=2, whiteboard_component='openshift-clients')]
+        expected = False
+        actual = bzutil.is_first_fix_any(flaw_bug, tracker_bugs, tr)
+        self.assertEqual(expected, actual)
+
     def test_is_first_fix_any_fail(self):
         hydra_data = {
             'package_state': [


### PR DESCRIPTION
Follow up to https://github.com/openshift-eng/elliott/pull/487

attach-cve-flaws fails when package_state is missing in hyrda response

Test: `elliott -g openshift-4.13 --assembly rc.0 attach-cve-flaws -a 111419 --noop`

Missing package_state can mean there are no unfixed components
Wait for Prodsec confirmation before merge: https://redhat-internal.slack.com/archives/CB95J6R4N/p1679348617881569