### PR TITLE
Fix devcontainer to use pyproject.toml

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -51,8 +51,8 @@ RUN groupadd --gid "$USER_GID" "$USERNAME" \
 WORKDIR /workspaces/elliott
 COPY . .
 RUN chown "$USERNAME" -R . \
- && sudo -u "$USERNAME" pip3 install --user -r ./requirements.txt -r requirements-dev.txt \
- && sudo -u "$USERNAME" pip3 install --user --editable .
+ && sudo -u "$USERNAME" pip3 install --user -U pip>=22.3 setuptools>=64 \
+ && sudo -u "$USERNAME" pip3 install --user --editable .[tests]
 USER "$USER_UID"
 ENV ELLIOTT_DATA_PATH=https://github.com/openshift-eng/ocp-build-data \
     _ELLIOTT_DATA_PATH=/workspaces/ocp-build-data

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 	// Uncomment the next line to run commands after the container is created - for example installing git.
-	"postCreateCommand": "sudo chown -R dev: /workspaces/elliott-working-dir && pip3 install --user -r requirements-dev.txt -r requirements.txt -e .",
+	"postCreateCommand": "sudo chown -R dev: /workspaces/elliott-working-dir && pip3 install --user --editable .[tests]",
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-python.python",


### PR DESCRIPTION
Newer versions of pip and setuptools are required to use `pip install -e`