### PR TITLE
Ignore when new jira bugs are not found in ET

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -702,7 +702,7 @@ class JIRABugTracker(BugTracker):
         bugs = list(bugs)
         api = AsyncErrataAPI()
         await api.login()
-        results = await asyncio.gather(*[api.get_advisories_for_jira(bug.id) for bug in bugs])
+        results = await asyncio.gather(*[api.get_advisories_for_jira(bug.id, ignore_not_found=True) for bug in bugs])
         attached_bugs = [bug for bug, advisories in zip(bugs, results) if advisories]
         await api.close()
         return attached_bugs

--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 from typing import Dict, Iterable, List, Set, Union
 from urllib.parse import quote, urlparse
+from aiohttp import ClientResponseError
 
 import aiohttp
 import gssapi
@@ -91,9 +92,17 @@ class AsyncErrataAPI:
         await self._make_request(aiohttp.hdrs.METH_DELETE, path, parse_json=False)
 
     @limit_concurrency(limit=16)
-    async def get_advisories_for_jira(self, jira_key: str):
+    async def get_advisories_for_jira(self, jira_key: str, ignore_not_found=False):
         path = f"/jira_issues/{quote(jira_key)}/advisories.json"
-        return await self._make_request(aiohttp.hdrs.METH_GET, path)
+        try:
+            result = await self._make_request(aiohttp.hdrs.METH_GET, path)
+        except ClientResponseError as e:
+            if ignore_not_found and e.status == 404:
+                result = []
+            else:
+                raise(e)
+        return result
+
 
     @limit_concurrency(limit=16)
     async def get_advisories_for_bug(self, bz_key: str):

--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -97,6 +97,8 @@ class AsyncErrataAPI:
         try:
             result = await self._make_request(aiohttp.hdrs.METH_GET, path)
         except ClientResponseError as e:
+            # When newly created jira bugs are not sync'd to ET we get a 404, 
+            # assume that they are not attached to any advisory
             if ignore_not_found and e.status == 404:
                 result = []
             else:

--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -102,7 +102,7 @@ class AsyncErrataAPI:
             if ignore_not_found and e.status == 404:
                 result = []
             else:
-                raise(e)
+                raise
         return result
 
 


### PR DESCRIPTION
We are doing an ET lookup for all found jira bugs - newly created jira bugs
will 404 since they are not sync'd. Handle that error instead of crashing

Tested with: `./elliott --data-path ../ocp-build-data -g openshift-4.14 --assembly stream find-bugs:sweep`
(without it) `2023-03-27 11:02:30,820 ERROR exception with jira bug tracker: 404, message='Not Found', url=URL('https://errata.devel.redhat.com/jira_issues/OCPBUGS-10908/advisories.json')`