### PR TITLE
verify-cvp: Fix missing variable failed_optional

### DIFF
--- a/elliottlib/cli/verify_cvp_cli.py
+++ b/elliottlib/cli/verify_cvp_cli.py
@@ -159,6 +159,7 @@ async def verify_cvp_cli(runtime: Runtime, all_images, nvrs, include_content_set
         yaml.dump(report, sys.stdout)
     else:
         print_report(report)
+        failed_optional = report.get("sanity_test_optional_checks", {}).get("failed")
         if failed or failed_optional:
             exit(2)
 


### PR DESCRIPTION
Fix the following error:

```
$ elliott -g openshift-4.13 --assembly rc.3 verify-cvp --all

  File "/mnt/workspace/users/yuxzhu/elliott/elliottlib/cli/verify_cvp_cli.py", line 162, in verify_cvp_cli
    if failed or failed_optional:
UnboundLocalError: local variable 'failed_optional' referenced before assignment
```