### PR TITLE
Detect and fix invalid trackers

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -727,22 +727,25 @@ class JIRABugTracker(BugTracker):
             status=status,
             with_target_release=True,
             search_filter=search_filter,
-            custom_query='and "Release Blocker" = "Approved"'
-        )
-        return self._search(query, verbose=verbose, **kwargs)
-
-    def search(self, status, search_filter='default', verbose=False):
-        query = self._query(
-            status=status,
-            search_filter=search_filter
+            custom_query=' and "Release Blocker" = "Approved"',
+            **kwargs
         )
         return self._search(query, verbose=verbose)
 
-    def cve_tracker_search(self, status, search_filter='default', verbose=False):
+    def search(self, status, search_filter='default', verbose=False, **kwargs):
+        query = self._query(
+            status=status,
+            search_filter=search_filter,
+            **kwargs
+        )
+        return self._search(query, verbose=verbose)
+
+    def cve_tracker_search(self, status, search_filter='default', verbose=False, **kwargs):
         query = self._query(
             status=status,
             search_filter=search_filter,
             include_labels=["SecurityTracking"],
+            **kwargs
         )
         return self._search(query, verbose=verbose)
 
@@ -838,15 +841,15 @@ class BugzillaBugTracker(BugTracker):
     def client(self):
         return self._client
 
-    def blocker_search(self, status, search_filter='default', verbose=False):
+    def blocker_search(self, status, search_filter='default', verbose=False, **kwargs):
         query = _construct_query_url(self.config, status, search_filter, flag='blocker+')
         return self._search(query, verbose)
 
-    def search(self, status, search_filter='default', verbose=False):
+    def search(self, status, search_filter='default', verbose=False, **kwargs):
         query = _construct_query_url(self.config, status, search_filter)
         return self._search(query, verbose)
 
-    def cve_tracker_search(self, status, search_filter='default', verbose=False):
+    def cve_tracker_search(self, status, search_filter='default', verbose=False, **kwargs):
         query = _construct_query_url(self.config, status, search_filter)
         query.addKeyword('SecurityTracking')
         return self._search(query, verbose)

--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -68,6 +68,7 @@ from elliottlib.cli.repair_bugs_cli import repair_bugs_cli
 from elliottlib.cli.find_unconsumed_rpms import find_unconsumed_rpms_cli
 from elliottlib.cli.find_bugs_kernel_cli import find_bugs_kernel_cli
 from elliottlib.cli.find_bugs_kernel_clones_cli import find_bugs_kernel_clones_cli
+from elliottlib.cli.find_bugs_invalid import find_bugs_invalid_cli
 
 # 3rd party
 import click
@@ -483,6 +484,8 @@ cli.add_command(repair_bugs_cli)
 cli.add_command(find_unconsumed_rpms_cli)
 cli.add_command(find_bugs_kernel_cli)
 cli.add_command(find_bugs_kernel_clones_cli)
+cli.add_command(find_bugs_invalid_cli)
+
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliottlib/cli/find_bugs_invalid.py
+++ b/elliottlib/cli/find_bugs_invalid.py
@@ -33,7 +33,10 @@ async def find_bugs_invalid_cli(runtime: Runtime, fix):
 
     bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
 
-    look_like_trackers = [b for b in bugs if b.is_cve_in_summary()]
+    def has_cve_in_summary(b):
+        return bool(re.search(r'CVE-\d+-\d+', b.summary))
+
+    look_like_trackers = [b for b in bugs if has_cve_in_summary(b)]
     report = {}
     actionable_bugs = {}
     for b in look_like_trackers:

--- a/elliottlib/cli/find_bugs_invalid.py
+++ b/elliottlib/cli/find_bugs_invalid.py
@@ -61,12 +61,12 @@ async def find_bugs_invalid_cli(runtime: Runtime, fix):
         issues = []
         labels = []
         if not b.is_tracker_bug():
-            issues.append(f"Missing tracker labels.")
+            issues.append("Missing tracker labels.")
         if not b.whiteboard_component:
-            issues.append(f"Missing component label.")
+            issues.append("Missing component label.")
             labels.append(f"pscomponent:{component}")
         if not b.corresponding_flaw_bug_ids:
-            issues.append(f"Missing flaw bug label.")
+            issues.append("Missing flaw bug label.")
             labels.extend([f"flaw:bz#{i}" for i in flaw_ids])
         elif not set(flaw_ids).issubset(set(b.corresponding_flaw_bug_ids)):
             issues.append(f"Flaw bug labels not found. Expected: {flaw_ids} to be in {b.corresponding_flaw_bug_ids}.")
@@ -90,10 +90,4 @@ async def find_bugs_invalid_cli(runtime: Runtime, fix):
                 bug = actionable_bugs[bug_id]
                 bug.bug.fields.labels.extend(labels)
                 bug.bug.update(fields={"labels": bug.bug.fields.labels})
-                click.echo(f"Added labels")
-
-
-    # bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug,
-    #                             with_target_release=False, custom_query=' AND "Target Version" is EMPTY AND '
-    #                                                                     'component != "Release"')
-    #click.echo(f'Found {len(bugs)} bugs with status={find_bugs_obj.status} and no Target Version set')
+                click.echo("Added labels")

--- a/elliottlib/cli/find_bugs_invalid.py
+++ b/elliottlib/cli/find_bugs_invalid.py
@@ -1,0 +1,96 @@
+import json
+import click
+import requests
+import re
+from elliottlib import (Runtime, logutil)
+from elliottlib.cli import common
+from elliottlib.cli.find_bugs_sweep_cli import FindBugsSweep
+
+logger = logutil.getLogger(__name__)
+
+
+@common.cli.command("find-bugs:invalid-trackers", short_help="Find ART managed jira tracker bugs that are missing or "
+                                                             "have incorrect labels ")
+@click.option('--fix', is_flag=True, default=False, help='Attempt to fix the bugs by adding missing labels')
+@click.pass_obj
+@common.click_coroutine
+async def find_bugs_invalid_cli(runtime: Runtime, fix):
+    """Find ART managed jira tracker bugs that are missing or have incorrect labels
+    And optionally fix them
+
+    Only to be used with --assembly=stream
+
+    $ elliott -g openshift-4.12 find-bugs:invalid-trackers
+
+    """
+    if runtime.assembly != 'stream':
+        raise click.BadParameter("This command is intended to work only with --assembly=stream",
+                                 param_hint='--assembly')
+
+    runtime.initialize()
+    find_bugs_obj = FindBugsSweep()
+    bug_tracker = runtime.bug_trackers('jira')
+
+    bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
+
+    look_like_trackers = [b for b in bugs if b.is_cve_in_summary()]
+    report = {}
+    actionable_bugs = {}
+    for b in look_like_trackers:
+        # "CVE-2022-23525 CVE-2022-23526 special-resource-operator-container: various flaws [openshift-4]"
+        # so we want to match CVE-2022-23525, CVE-2022-23526 into a list
+        # and get special-resource-operator-container as the component
+
+        match = re.search(r'((?:CVE-\d+-\d+ )+)((?:\w+-?)+):', b.summary)
+        component = match.group(2)
+        cve_list = [c.strip() for c in match.group(1).split()]
+
+        cve_url = "https://access.redhat.com/hydra/rest/securitydata/cve/{cve_name}.json"
+
+        flaw_ids = []
+        for cve in cve_list:
+            url = cve_url.format(cve_name=cve)
+            response = requests.get(url)
+            response.raise_for_status()
+            flaw_id = response.json()['bugzilla']['id']
+            flaw_ids.append(int(flaw_id))
+
+        issues = []
+        labels = []
+        if not b.is_tracker_bug():
+            issues.append(f"Missing tracker labels.")
+        if not b.whiteboard_component:
+            issues.append(f"Missing component label.")
+            labels.append(f"pscomponent:{component}")
+        if not b.corresponding_flaw_bug_ids:
+            issues.append(f"Missing flaw bug label.")
+            labels.extend([f"flaw:bz#{i}" for i in flaw_ids])
+        elif not set(flaw_ids).issubset(set(b.corresponding_flaw_bug_ids)):
+            issues.append(f"Flaw bug labels not found. Expected: {flaw_ids} to be in {b.corresponding_flaw_bug_ids}.")
+
+        if issues:
+            report[b.id] = {'issues': ' '.join(issues), 'labels': labels}
+            actionable_bugs[b.id] = b
+
+    click.echo(f'Found {len(report)} bugs that are invalid')
+    click.echo(json.dumps(report, indent=4))
+
+    if not fix:
+        return
+
+    for bug_id, data in report.items():
+        labels = data['labels']
+        if labels:
+            bug = actionable_bugs[bug_id]
+            click.echo(f'{bug.id}({bug.status}) - {bug.summary}')
+            if click.confirm(f"Add labels {labels} to bug {bug_id}?"):
+                bug = actionable_bugs[bug_id]
+                bug.bug.fields.labels.extend(labels)
+                bug.bug.update(fields={"labels": bug.bug.fields.labels})
+                click.echo(f"Added labels")
+
+
+    # bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug,
+    #                             with_target_release=False, custom_query=' AND "Target Version" is EMPTY AND '
+    #                                                                     'component != "Release"')
+    #click.echo(f'Found {len(bugs)} bugs with status={find_bugs_obj.status} and no Target Version set')

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -30,16 +30,17 @@ class FindBugsMode:
     def exclude_status(self, status: List):
         self.status -= set(status)
 
-    def search(self, bug_tracker_obj: BugTracker, verbose: bool = False):
+    def search(self, bug_tracker_obj: BugTracker, verbose: bool = False, **kwargs):
         func = bug_tracker_obj.cve_tracker_search if self.cve_only else bug_tracker_obj.search
         return func(
             self.status,
-            verbose=verbose
+            verbose=verbose,
+            **kwargs
         )
 
 
 class FindBugsSweep(FindBugsMode):
-    def __init__(self, cve_only: bool):
+    def __init__(self, cve_only: bool = False):
         super().__init__(status={'MODIFIED', 'ON_QA', 'VERIFIED'}, cve_only=cve_only)
 
 


### PR DESCRIPTION
TODO:
- [ ] Add an option to comment on the bugs with suggested modifications (when running without --fix)
- [ ] When labels are added with --fix - post a comment about it

```
$ elliott -g openshift-4.12 find-bugs:invalid-trackers --fix
2023-06-22 15:03:05,377 INFO Cloning config data from https://github.com/openshift-eng/ocp-build-data.git
2023-06-22 15:03:09,310 INFO Using branch from group.yml: rhaos-4.12-rhel-8
Found 1 bugs that are invalid
{
    "OCPBUGS-9892": {
        "issues": "Missing tracker labels. Missing component label. Missing flaw bug label.",
        "labels": [
            "pscomponent:podman",
            "flaw:bz#2107342"
        ]
    }
}
OCPBUGS-9892(Verified) - CVE-2022-30631 podman: golang: compress/gzip: stack exhaustion in Reader.Read [openshift-4]
Add labels ['pscomponent:podman', 'flaw:bz#2107342'] to bug OCPBUGS-9892? [y/N]: y
Added labels

```