### PR TITLE
Move to another API to list advisory builds

### DIFF
--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -50,7 +50,9 @@ class AsyncErrataAPI:
         return await self._make_request(aiohttp.hdrs.METH_GET, path)
 
     async def get_builds(self, advisory: Union[int, str]):
-        path = f"/api/v1/erratum/{quote(str(advisory))}/builds_list"
+        # As of May 25, 2023, /api/v1/erratum/{id}/builds_list doesn't return all builds.
+        # Use /api/v1/erratum/{id}/builds instead.
+        path = f"/api/v1/erratum/{quote(str(advisory))}/builds"
         return await self._make_request(aiohttp.hdrs.METH_GET, path)
 
     async def get_builds_flattened(self, advisory: Union[int, str]) -> Set[str]:

--- a/tests/test_errata_async.py
+++ b/tests/test_errata_async.py
@@ -62,7 +62,7 @@ class TestAsyncErrataAPI(IsolatedAsyncioTestCase):
             "ProductVersion2": {"builds": [{"c-1.0.0-1": {}}]}
         }
         actual = await api.get_builds(1)
-        _make_request.assert_awaited_once_with(ANY, "GET", "/api/v1/erratum/1/builds_list")
+        _make_request.assert_awaited_once_with(ANY, "GET", "/api/v1/erratum/1/builds")
         self.assertEqual(actual, _make_request.return_value)
 
     @patch("aiohttp.ClientSession", autospec=True)
@@ -74,7 +74,7 @@ class TestAsyncErrataAPI(IsolatedAsyncioTestCase):
             "ProductVersion2": {"builds": [{"c-1.0.0-1": {}}]}
         }
         actual = await api.get_builds_flattened(1)
-        _make_request.assert_awaited_once_with(ANY, "GET", "/api/v1/erratum/1/builds_list")
+        _make_request.assert_awaited_once_with(ANY, "GET", "/api/v1/erratum/1/builds")
         self.assertEqual(actual, {"a-1.0.0-1", "b-1.0.0-1", "c-1.0.0-1"})
 
     @patch("aiohttp.ClientSession", autospec=True)


### PR DESCRIPTION
API /api/v1/erratum/{id}/builds_list seems to be problematic. With advisory 114782 it is missing one build.

Use /api/v1/erratum/{id}/builds instead.