### PR TITLE
[ART-6964] New commands to clone and move kernel bugs

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -66,6 +66,8 @@ from elliottlib.cli.find_bugs_blocker_cli import find_bugs_blocker_cli
 from elliottlib.cli.remove_bugs_cli import remove_bugs_cli
 from elliottlib.cli.repair_bugs_cli import repair_bugs_cli
 from elliottlib.cli.find_unconsumed_rpms import find_unconsumed_rpms_cli
+from elliottlib.cli.find_bugs_kernel_cli import find_bugs_kernel_cli
+from elliottlib.cli.find_bugs_kernel_clones_cli import find_bugs_kernel_clones_cli
 
 # 3rd party
 import click
@@ -479,7 +481,8 @@ cli.add_command(find_bugs_blocker_cli)
 cli.add_command(remove_bugs_cli)
 cli.add_command(repair_bugs_cli)
 cli.add_command(find_unconsumed_rpms_cli)
-
+cli.add_command(find_bugs_kernel_cli)
+cli.add_command(find_bugs_kernel_clones_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliottlib/cli/find_bugs_kernel_cli.py
+++ b/elliottlib/cli/find_bugs_kernel_cli.py
@@ -1,0 +1,335 @@
+import re
+import sys
+from typing import Any, Dict, List, Optional, Sequence, TextIO, Tuple, cast
+
+import click
+import koji
+from bugzilla import Bugzilla
+from bugzilla.bug import Bug
+from jira import JIRA, Issue
+
+from elliottlib import Runtime, brew
+from elliottlib.assembly import AssemblyTypes
+from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.config_model import KernelBugSweepConfig
+from elliottlib.exceptions import ElliottFatalError
+from elliottlib.util import green_print
+
+
+class FindBugsKernelCli:
+    def __init__(self, runtime: Runtime, trackers: Sequence[str],
+                 clone: bool, reconcile: bool, comment: bool, dry_run: bool):
+        self._runtime = runtime
+        self._logger = runtime.logger
+        self.trackers = list(trackers)
+        self.clone = clone
+        self.reconcile = reconcile
+        self.comment = comment
+        self.dry_run = dry_run
+        self._id_bugs: Dict[int, Bug] = {}  # cache for kernel bug; key is bug_id, value is Bug object
+        self._tracker_map: Dict[int, Issue] = {}  # bug_id -> KMAINT jira mapping
+
+    async def run(self):
+        logger = self._logger
+        if self.reconcile and not self.clone:
+            raise ElliottFatalError("--reconcile must be used with --clone")
+        if self._runtime.assembly_type is not AssemblyTypes.STREAM:
+            raise ElliottFatalError("This command only supports stream assembly")
+        group_config = self._runtime.group_config
+        raw_config = self._runtime.gitdata.load_data(key='bug', replace_vars=group_config.vars).data.get("kernel_bug_sweep")
+        if not raw_config:
+            logger.warning("kernel_bug_sweep is not defined in bug.yml")
+            return
+        config = KernelBugSweepConfig.parse_obj(raw_config)
+        jira_tracker = self._runtime.bug_trackers("jira")
+        jira_client: JIRA = jira_tracker._client
+        bz_tracker = self._runtime.bug_trackers("bugzilla")
+        bz_client: Bugzilla = bz_tracker._client
+        koji_api = self._runtime.build_retrying_koji_client(caching=True)
+
+        # Getting KMAINT trackers
+        trackers_keys = self.trackers
+        trackers: List[Issue] = []
+        if not trackers_keys:
+            logger.info("Searching for open trackers...")
+            trackers = self._find_kmaint_trackers(jira_client, config.tracker_jira.project, config.tracker_jira.labels)
+            trackers_keys = [t.key for t in trackers]
+            logger.info("Found %s tracker(s): %s", len(trackers_keys), trackers_keys)
+        else:
+            logger.info("Find kernel bugs linked from KMAINT tracker(s): %s", trackers_keys)
+            for key in trackers_keys:
+                logger.info("Getting tracker JIRA %s...", key)
+                tracker = jira_client.issue(key)
+                trackers.append(tracker)
+
+        # Get kernel bugs linked from KMAINT trackers
+        report: Dict[str, Any] = {"kernel_bugs": []}
+        for tracker in trackers:
+            bugs = self._find_bugs(jira_client, tracker, bz_client, config.bugzilla.target_releases)
+            bug_ids = {int(b.id) for b in bugs}
+            logger.info("Found %s bug(s) from %s: %s", len(bugs), tracker, bug_ids)
+            for bug_id, bug in zip(bug_ids, bugs):
+                if bug_id in self._tracker_map and self._tracker_map[bug_id].key != tracker.key:
+                    raise ValueError(f"Bug {bug_id} is linked in multiple KMAINT trackers: {tracker.key} {self._tracker_map[bug_id].key}")
+                self._id_bugs[bug_id] = bug
+                self._tracker_map[bug_id] = tracker
+                report["kernel_bugs"].append({
+                    "id": bug_id,
+                    "status": bug.status,
+                    "summary": bug.summary,
+                    "tracker": tracker,
+                })
+            if self.comment:
+                logger.info("Checking if making a comment on tracker %s is needed...", tracker.key)
+                self._comment_on_tracker(jira_client, tracker, koji_api, config.target_jira)
+
+        if self.clone and self._id_bugs:
+            # Clone kernel bugs into OCP Jira
+            logger.info("Cloning bugs...")
+            cloned_issues = self._clone_bugs(jira_client, list(self._id_bugs.values()), config.target_jira)
+            report["clones"] = {}
+            for bug_id, issues in cloned_issues.items():
+                report["clones"][bug_id] = sorted(issue.key for issue in issues)
+            logger.info("Done.")
+
+        # Print a report
+        self._print_report(report, sys.stdout)
+
+    @staticmethod
+    def _find_kmaint_trackers(jira_client: JIRA, tracker_project: str, labels: List[str]):
+        conditions = [
+            f"project = {tracker_project}",
+            "status != Closed",
+        ]
+        if labels:
+            conditions.extend([f"labels = \"{label}\"" for label in labels])
+        jql = f'{" AND ".join(conditions)} ORDER BY created DESC'
+        # 50 most recently created KMAINT trackers should be more than enough
+        matched_issues = jira_client.search_issues(jql, maxResults=50)
+        return cast(List[Issue], matched_issues)
+
+    def _find_bugs(self, jira_client: JIRA, tracker: Issue, bz_client: Bugzilla, bz_target_releases: Sequence[str]):
+        logger = self._logger
+        logger.info("Searching bugs in JIRA %s...", tracker.key)
+        links = jira_client.remote_links(tracker.key)
+        # Search for kernel bugs in tracker content
+        pattern = re.compile(r"(?:bugzilla.redhat.com/|bugzilla.redhat.com/show_bug.cgi\?id=|bz)(\d+)")
+        content = f"{tracker.fields.summary}\n{tracker.fields.description}"
+        for link in links:
+            content += f"\n{link.object.title}\n{link.object.url}"
+        m = pattern.findall(content)
+        bug_ids = sorted(set(map(int, m)))
+        if not bug_ids:
+            logger.info("No bugs found from %s", tracker.key)
+            return []
+        filtered_bugs = self._get_and_filter_bugs(bz_client, bug_ids, bz_target_releases)
+        return filtered_bugs
+
+    def _get_and_filter_bugs(self, bz_client: Bugzilla, bug_ids: List[int], bz_target_releases: Sequence[str]):
+        """ Get specified bugs from Bugzilla, then return those bugs that match the defined target release.
+        """
+        logger = self._logger
+        filtered_bugs: List[Bug] = []
+        logger.info("Getting bugs %s from Bugzilla...", bug_ids)
+        bugs = cast(List[Optional[Bug]], bz_client.getbugs(bug_ids))
+        target_releases = set(bz_target_releases)
+        for bug_id, bug in zip(bug_ids, bugs):
+            if not bug:
+                raise IOError(f"Error getting bug {bug_id}")
+            target_release = bug.cf_zstream_target_release
+            if not target_release:
+                logger.warning("Target release of bug %s is not set", bug.weburl)
+                continue
+            if target_release not in target_releases:
+                logger.warning("Bug %s is skipped because target release \"%s\" is not listed", bug.weburl, target_release)
+                continue
+            logger.info("Found bug %s matching target release %s", bug_id, target_release)
+            filtered_bugs.append(bug)
+        return filtered_bugs
+
+    def _clone_bugs(self, jira_client: JIRA, bugs: Sequence[Bug], conf: KernelBugSweepConfig.TargetJiraConfig):
+        logger = self._logger
+        ocp_target_release = conf.target_release
+        result: Dict[int, List[Issue]] = {}  # key is bug_id, value is a list of cloned jiras
+        for bug in bugs:
+            bug_id = int(bug.id)
+            kmaint_tracker = self._tracker_map.get(bug_id)
+            kmaint_tracker_key = kmaint_tracker.key if kmaint_tracker else None
+            logger.info("Checking if %s was already cloned to OCP %s...", bug_id, ocp_target_release)
+            jql_str = f'project = {conf.project} and component = {conf.component} and labels = art:cloned-kernel-bug and labels = "art:bz#{bug_id}" and "Target Version" = "{ocp_target_release}" order by created DESC'
+            found_issues = cast(List[Issue], jira_client.search_issues(jql_str=jql_str))
+            if not found_issues:  # this bug is not already cloned into OCP Jira
+                logger.info("Creating JIRA for bug %s...", bug.weburl)
+                fields = self._new_jira_fields_from_bug(bug, ocp_target_release, kmaint_tracker_key, conf)
+                if not self.dry_run:
+                    issue = jira_client.create_issue(fields)
+                    jira_client.add_remote_link(issue.key, {"title": f"BZ{bug_id}", "url": bug.weburl})
+                    if kmaint_tracker:
+                        jira_client.create_issue_link("Blocks", issue.key, kmaint_tracker)
+                    result[bug_id] = [issue]
+                else:
+                    logger.warning("[DRY RUN] Would have created Jira for bug %s", bug_id)
+            else:  # this bug is already cloned into OCP Jira
+                logger.info("Bug %s is already cloned into OCP: %s", bug_id, [issue.key for issue in found_issues])
+                result[bug_id] = found_issues
+                if not self.reconcile:
+                    continue
+                fields = self._new_jira_fields_from_bug(bug, ocp_target_release, kmaint_tracker_key, conf)
+                for issue in found_issues:
+                    if issue.fields.status.name.lower() == "closed":
+                        logger.info("No need to reconcile %s because it is Closed.", issue.key)
+                        continue
+                    logger.info("Reconciling Jira %s (cloned from bug %s) for %s", issue.key, bug_id, ocp_target_release)
+                    if not self.dry_run:
+                        issue.update(fields)
+                    else:
+                        logger.warning("[DRY RUN] Would have updated Jira %s to match bug %s", issue.key, bug_id)
+
+        return result
+
+    @staticmethod
+    def _print_report(report: Dict, out: TextIO):
+        print_func = green_print if out.isatty() else print  # use green_print if out is a TTY
+        bugs = sorted(report.get("kernel_bugs", []), key=lambda bug: bug["id"])
+        clones = report.get("clones", {})
+        for bug in bugs:
+            cloned_issues = clones.get(bug['id'], [])
+            text = f"{bug['tracker']}\t{bug['id']}\t{'N/A' if not cloned_issues else ','.join(cloned_issues)}\t{bug['status']}\t{bug['summary']}"
+            print_func(text, file=out)
+
+    def _comment_on_tracker(self, jira_client: JIRA, tracker: Issue, koji_api: koji.ClientSession,
+                            conf: KernelBugSweepConfig.TargetJiraConfig):
+        logger = self._runtime.logger
+        # Determine which NVRs have the fix. e.g. ["kernel-5.14.0-284.14.1.el9_2"]
+        nvrs = re.findall(r"(kernel(?:-rt)?-\S+-\S+)", tracker.fields.summary)
+        if not nvrs:
+            raise ValueError("Couldn't determine build NVRs for tracker %s", tracker.key)
+        nvrs = sorted(nvrs)
+        # Check if nvrs are already tagged into OCP
+        logger.info("Getting Brew tags for build(s) %s...", nvrs)
+        candidate_brew_tag = conf.candidate_brew_tag
+        prod_brew_tag = conf.prod_brew_tag
+        build_tags = brew.get_builds_tags(nvrs, koji_api)
+        shipped = all([any(map(lambda t: t["name"] == prod_brew_tag, tags)) for tags in build_tags])
+        modified = all([any(map(lambda t: t["name"] == candidate_brew_tag, tags)) for tags in build_tags])
+        tracker_message = None
+        if shipped:
+            tracker_message = f"Build(s) {nvrs} was/were already shipped and tagged into {prod_brew_tag}."
+        elif modified:
+            tracker_message = f"Build(s) {nvrs} was/were already tagged into {candidate_brew_tag}."
+        if not tracker_message:
+            logger.info("No need to make a comment on %s", tracker.key)
+            return
+        comments = jira_client.comments(tracker.key)
+        if any(map(lambda comment: comment.body == tracker_message, comments)):
+            logger.info("A comment was already made on %s", tracker.key)
+            return
+        logger.info("Making a comment on tracker %s", tracker.key)
+        if not self.dry_run:
+            jira_client.add_comment(tracker.key, tracker_message)
+            logger.info("Left a comment on tracker %s", tracker.key)
+        else:
+            logger.warning("[DRY RUN] Would have left a comment on tracker %s", tracker.key)
+
+    @staticmethod
+    def _new_jira_fields_from_bug(bug: Bug, ocp_target_version: str, kmaint_tracker: Optional[str], conf: KernelBugSweepConfig.TargetJiraConfig):
+        summary = f"{bug.summary} [rhocp-{ocp_target_version}]"
+        if not summary.startswith("kernel"):  # ensure bug summary start with "kernel"
+            summary = "kernel[-rt]: " + summary
+        description = f"Cloned from {bug.weburl} by OpenShift ART Team:\n----\n{bug.description}"
+        priority_mapping = {
+            "urgent": "Critical",
+            "high": "Major",
+            "medium": "Normal",
+            "low": "Minor",
+            "unspecified": "Undefined",
+        }
+        bug_groups = set(bug.groups)
+        fields = {
+            "project": {"key": conf.project},
+            "components": [{"name": conf.component}],
+            "security": {'name': 'Red Hat Employee'} if 'private' in bug_groups or 'redhat' in bug_groups else None,
+            "priority": {'name': priority_mapping.get(bug.priority, "Undefined")},
+            "summary": summary,
+            "description": description,
+            "issuetype": {"name": "Bug"},
+            "versions": [{"name": ocp_target_version[:ocp_target_version.rindex(".")]}],
+            "customfield_12319940": [{
+                "name": ocp_target_version,
+            }],
+            "labels": ["art:cloned-kernel-bug", f"art:bz#{bug.id}"],
+        }
+        if kmaint_tracker:
+            fields["labels"].append(f"art:kmaint:{kmaint_tracker}")
+
+        # TODO: The following lines are commented out because we haven't reached to agreement
+        # on how to handle kernel CVEs in OCP at this moment.
+        # Without the following lines, kernel CVEs will be copied as normal (non-CVE) bugs.
+
+        # is_cve_tracker = set(constants.TRACKER_BUG_KEYWORDS).issubset(set(bug.keywords))
+        # if is_cve_tracker:
+        #     # Find flaw bugs associated with the CVE tracker
+        #     cve_flaws = []
+        #     for flaw_id, flaw_bug in zip(bug.blocks, bug.bugzilla.getbugs(bug.blocks)):
+        #         if not flaw_bug:
+        #             raise IOError(f"Error getting flaw bug {flaw_id}. Permission issue?")
+        #         if not BugzillaBug(flaw_bug).is_flaw_bug():
+        #             continue  # this is not a flaw bug
+        #         cve_flaws.append(flaw_bug)
+        #     labels = {"Security", "SecurityTracking"}
+        #     cve_names = re.findall(r"(CVE-\d+-\d+)", bug.summary)
+        #     labels |= set(cve_names)
+        #     labels |= {f"pscomponent:{component}" for component in bug.components}
+        #     labels |= {f"flaw:bz#{flaw.id}" for flaw in cve_flaws}
+        #     fields["labels"] += sorted(labels)
+        return fields
+
+
+@cli.command("find-bugs:kernel", short_help="Find kernel bugs")
+@click.option("--tracker", "trackers", metavar='JIRA_KEY', multiple=True,
+              help="Find by the specified KMAINT tracker JIRA_KEY")
+@click.option("--clone",
+              is_flag=True,
+              default=False,
+              help="Clone kernel bugs into OCP Jira")
+@click.option("--reconcile",
+              is_flag=True,
+              default=False,
+              help="Update summary, description, etc for already cloned Jira bugs. Must be used with --clone")
+@click.option("--comment",
+              is_flag=True,
+              default=False,
+              help="Make comments on KMAINT trackers")
+@click.option("--dry-run",
+              is_flag=True,
+              default=False,
+              help="Don't change anything")
+@click.pass_obj
+@click_coroutine
+async def find_bugs_kernel_cli(
+        runtime: Runtime, trackers: Tuple[str, ...], clone: bool,
+        reconcile: bool, comment: bool, dry_run: bool):
+    """Find kernel bugs in Bugzilla for weekly kernel release through OCP.
+
+    Example 1: Find kernel bugs and print them out
+    \b
+        $ elliott -g openshift-4.14 find-bugs:kernel
+
+    Example 2: Find kernel bugs and clone them into OCP Jira
+    \b
+        $ elliott -g openshift-4.14 find-bugs:kernel --clone
+
+    Example 3: Clone kernel bugs into OCP Jira and also update already cloned Jiras
+    \b
+        $ elliott -g openshift-4.14 find-bugs:kernel --clone --reconcile
+    """
+    runtime.initialize(mode="none")
+    cli = FindBugsKernelCli(
+        runtime=runtime,
+        trackers=trackers,
+        clone=clone,
+        reconcile=reconcile,
+        comment=comment,
+        dry_run=dry_run
+    )
+    await cli.run()

--- a/elliottlib/cli/find_bugs_kernel_clones_cli.py
+++ b/elliottlib/cli/find_bugs_kernel_clones_cli.py
@@ -1,0 +1,250 @@
+import re
+import sys
+from typing import Dict, List, Optional, Sequence, TextIO, Tuple, cast
+
+import click
+import koji
+from jira import JIRA, Issue
+
+from elliottlib import Runtime, brew
+from elliottlib.assembly import AssemblyTypes
+from elliottlib.cli.common import cli, click_coroutine
+from elliottlib.config_model import KernelBugSweepConfig
+from elliottlib.exceptions import ElliottFatalError
+from elliottlib.util import green_print
+
+
+class FindBugsKernelClonesCli:
+    def __init__(self, runtime: Runtime, trackers: Sequence[str], issues: Sequence[str],
+                 move: bool, comment: bool, dry_run: bool):
+        self._runtime = runtime
+        self._logger = runtime.logger
+        self.trackers = list(trackers)
+        self.issues = list(issues)
+        self.move = move
+        self.comment = comment
+        self.dry_run = dry_run
+
+    async def run(self):
+        logger = self._logger
+        if self.comment and not self.move:
+            raise ElliottFatalError("--comment must be used with --move")
+        if self._runtime.assembly_type is not AssemblyTypes.STREAM:
+            raise ElliottFatalError("This command only supports stream assembly.")
+        group_config = self._runtime.group_config
+        raw_config = self._runtime.gitdata.load_data(key='bug', replace_vars=group_config.vars).data.get("kernel_bug_sweep")
+        if not raw_config:
+            logger.warning("kernel_bug_sweep is not defined in bug.yml")
+            return
+        config = KernelBugSweepConfig.parse_obj(raw_config)
+        jira_tracker = self._runtime.bug_trackers("jira")
+        jira_client: JIRA = jira_tracker._client
+        koji_api = self._runtime.build_retrying_koji_client(caching=True)
+
+        # Search for Jiras
+        report = {"jira_issues": []}
+        if self.issues:
+            logger.info("Getting specified Jira issues %s...", self.issues)
+            found_issues = self._get_jira_issues(jira_client, self.issues, config)
+        else:
+            logger.info("Searching for bug clones in Jira project %s...", config.target_jira.project)
+            found_issues = self._search_for_jira_issues(jira_client, self.trackers, config)
+        issue_keys = [issue.key for issue in found_issues]
+        logger.info("Found %s Jira(s) in %s: %s", len(issue_keys), config.target_jira.project, issue_keys)
+
+        # Update JIRA issues
+        if self.move and found_issues:
+            logger.info("Moving bug clones...")
+            self._update_jira_issues(jira_client, found_issues, koji_api, config)
+            logger.info("Done.")
+
+        # Print a report
+        report["jira_issues"] = [{
+            "key": issue.key,
+            "summary": issue.fields.summary,
+            "status": str(issue.fields.status.name),
+        } for issue in found_issues]
+        self._print_report(report, sys.stdout)
+
+    def _get_jira_issues(self, jira_client: JIRA, issue_keys: List[str], config: KernelBugSweepConfig):
+        found_issues: List[Issue] = []
+        labels = {"art:cloned-kernel-bug"}
+        for key in issue_keys:
+            issue = jira_client.issue(key)
+            if not labels.issubset(set(issue.fields.labels)):
+                raise ValueError(f"Jira {key} doesn't have all required labels {labels}")
+            if issue.fields.project.key != config.target_jira.project:
+                raise ValueError(f"Jira {key} doesn't belong to project {config.target_jira.project}")
+            components = {c.name for c in issue.fields.components}
+            if config.target_jira.component not in components:
+                raise ValueError(f"Jira {key} is not set to component {config.target_jira.component}")
+            target_releases = {t.name for t in issue.fields.customfield_12319940}
+            if config.target_jira.target_release not in target_releases:
+                raise ValueError(f"Jira {key} has invalid target version: {issue.fields.customfield_12319940.name}")
+            found_issues.append(issue)
+        return found_issues
+
+    @staticmethod
+    def _search_for_jira_issues(jira_client: JIRA, trackers: Optional[List[str]],
+                                config: KernelBugSweepConfig):
+        conditions = [
+            "labels = art:cloned-kernel-bug",
+            f"project = {config.target_jira.project}",
+            f"component = {config.target_jira.component}",
+            f"\"Target Version\" = \"{config.target_jira.target_release}\"",
+        ]
+        if trackers:
+            condition = ' OR '.join(map(lambda t: f"labels = art:kmaint:{t}", trackers))
+            conditions.append(f"({condition})")
+        jql_str = f'{" AND ".join(conditions)} order by created DESC'
+        found_issues = jira_client.search_issues(jql_str, maxResults=0)
+        return cast(List[Issue], found_issues)
+
+    def _update_jira_issues(self, jira_client: JIRA,
+                            issues: List[Issue],
+                            koji_api: koji.ClientSession,
+                            config: KernelBugSweepConfig):
+        logger = self._runtime.logger
+        candidate_brew_tag = config.target_jira.candidate_brew_tag
+        prod_brew_tag = config.target_jira.prod_brew_tag
+        trackers: Dict[str, Issue] = {}
+        tracker_issues: Dict[str, List[Issue]] = {}
+        issue_bug_ids: Dict[str, int] = {}
+        for issue in issues:
+            # extract bug id from labels: ["art:bz#12345"] -> 12345
+            bug_id = next(map(lambda m: int(m[1]), filter(bool, map(lambda label: re.fullmatch(r"art:bz#(\d+)", label), issue.fields.labels))), None)
+            if not bug_id:
+                raise ValueError(f"Jira clone {issue.key} doesn't have the required `art:bz#N` label")
+            issue_bug_ids[issue.key] = bug_id
+            # extract KMAINT tracker key from labels: ["art:kmaint:KMAINT-1"] -> KMAINT-1
+            tracker_key = next(map(lambda m: str(m[1]), filter(bool, map(lambda label: re.fullmatch(r"art:kmaint:(\S+)", label), issue.fields.labels))), None)
+            if not tracker_key:
+                raise ValueError(f"Jira clone {issue.key} doesn't have the required `art:kmaint:*` label")
+            tracker = trackers.get(tracker_key)
+            if not tracker:
+                tracker = trackers[tracker_key] = jira_client.issue(tracker_key)
+                if tracker.fields.project.key != config.tracker_jira.project:
+                    raise ValueError(f"KMAINT tracker {tracker_key} is not in project {config.tracker_jira.project}")
+                if not set(config.tracker_jira.labels).issubset(set(tracker.fields.labels)):
+                    raise ValueError(f"KMAINT tracker {tracker_key} doesn't have required labels {config.tracker_jira.labels}")
+            tracker_issues.setdefault(tracker.key, []).append(issue)
+
+        for tracker_id, tracker in trackers.items():
+            # Determine which NVRs have the fix. e.g. ["kernel-5.14.0-284.14.1.el9_2"]
+            nvrs = re.findall(r"(kernel(?:-rt)?-\S+-\S+)", tracker.fields.summary)
+            if not nvrs:
+                raise ValueError("Couldn't determine build NVRs for bug %s. Bug status will not be moved.", bug_id)
+            nvrs = sorted(nvrs)
+            issues = tracker_issues[tracker_id]
+            issue_keys = [issue.key for issue in issues]
+            # Check if nvrs are already tagged into OCP
+            logger.info("Getting Brew tags for build(s) %s...", nvrs)
+            build_tags = brew.get_builds_tags(nvrs, koji_api)
+            shipped = all([any(map(lambda t: t["name"] == prod_brew_tag, tags)) for tags in build_tags])
+            tracker_message = None
+            if shipped:
+                logger.info("Build(s) %s shipped (tagged into %s). Moving Jira(s) %s to CLOSED...", nvrs, prod_brew_tag, issue_keys)
+                for issue in issues:
+                    current_status: str = issue.fields.status.name
+                    new_status = 'CLOSED'
+                    if current_status.lower() != "closed":
+                        new_status = 'CLOSED'
+                        message = f"Elliott changed bug status from {current_status} to {new_status} because {nvrs} was/were already shipped and tagged into {prod_brew_tag}."
+                        self._move_jira(jira_client, issue, new_status, message)
+                    else:
+                        logger.info("No need to move %s because its status is %s", issue.key, current_status)
+                tracker_message = f"Build(s) {nvrs} was/were already shipped and tagged into {prod_brew_tag}."
+            else:
+                modified = all([any(map(lambda t: t["name"] == candidate_brew_tag, tags)) for tags in build_tags])
+                if modified:
+                    logger.info("Build(s) %s tagged into %s. Moving Jira(s) %s to MODIFIED...", nvrs, candidate_brew_tag, issue_keys)
+                    for issue in issues:
+                        current_status: str = issue.fields.status.name
+                        if current_status.lower() in {"new", "assigned", "post"}:
+                            new_status = 'MODIFIED'
+                            message = f"Elliott changed bug status from {current_status} to {new_status} because {nvrs} was/were already tagged into {candidate_brew_tag}."
+                            self._move_jira(jira_client, issue, new_status, message)
+                        else:
+                            logger.info("No need to move %s because its status is %s", issue.key, current_status)
+                    tracker_message = f"Build(s) {nvrs} was/were already tagged into {candidate_brew_tag}."
+            if self.comment and tracker_message:
+                logger.info("Checking if making a comment on tracker %s is needed", tracker.key)
+                comments = jira_client.comments(tracker.key)
+                if any(map(lambda comment: comment.body == tracker_message, comments)):
+                    logger.info("A comment was already made on %s", tracker.key)
+                    continue
+                logger.info("Making a comment on tracker %s", tracker.key)
+                if not self.dry_run:
+                    jira_client.add_comment(tracker.key, tracker_message)
+                    logger.info("Left a comment on tracker %s", tracker.key)
+                else:
+                    logger.warning("[DRY RUN] Would have left a comment on tracker %s", tracker.key)
+
+    def _move_jira(self, jira_client: JIRA, issue: Issue, new_status: str, comment: Optional[str]):
+        logger = self._runtime.logger
+        current_status: str = issue.fields.status.name
+        logger.info("Moving %s from %s to %s", issue.key, current_status, new_status)
+        if not self.dry_run:
+            jira_client.assign_issue(issue.key, jira_client.current_user())
+            jira_client.transition_issue(issue.key, new_status)
+            if comment:
+                jira_client.add_comment(issue.key, comment)
+            logger.info("Moved %s from %s to %s", issue.key, current_status, new_status)
+        else:
+            logger.warning("[DRY RUN] Would have moved Jira %s from %s to %s", issue.key, current_status, new_status)
+
+    @staticmethod
+    def _print_report(report: Dict, out: TextIO):
+        print_func = green_print if out.isatty() else print  # use green_print if out is a TTY
+        jira_issues = sorted(report.get("jira_issues", []), key=lambda issue: issue["key"])
+        for issue in jira_issues:
+            text = f"{issue['key']}\t{issue['status']}\t{issue['summary']}"
+            print_func(text, file=out)
+
+
+@cli.command("find-bugs:kernel-clones", short_help="Find kernel bugs")
+@click.option("--tracker", "trackers", metavar='JIRA_KEY', multiple=True,
+              help="Find by the specified KMAINT tracker JIRA_KEY")
+@click.option("--issue", "issues", metavar='JIRA_KEY', multiple=True,
+              help="Find by the specified Jira bug JIRA_KEY")
+@click.option("--move",
+              is_flag=True,
+              default=False,
+              help="Auto move Jira bugs to MODIFIED or CLOSED")
+@click.option("--comment",
+              is_flag=True,
+              default=False,
+              help="Make comments on KMAINT trackers")
+@click.option("--dry-run",
+              is_flag=True,
+              default=False,
+              help="Don't change anything")
+@click.pass_obj
+@click_coroutine
+async def find_bugs_kernel_clones_cli(
+        runtime: Runtime, trackers: Tuple[str, ...], issues: Tuple[str, ...],
+        move: bool, comment: bool, dry_run: bool):
+    """Find cloned kernel bugs in JIRA for weekly kernel release through OCP.
+
+    Example 1: List all bugs in JIRA
+    \b
+        $ elliott -g openshift-4.14 find-bugs:kernel-clones
+
+    Example 2: Move bugs to MODIFIED/CLOSED based on what Brew tags that the builds have.
+    \b
+        $ elliott -g openshift-4.14 find-bugs:kernel-clones --move
+
+    Example 3: Move bugs and leave a comment on the KMAINT tracker
+    \b
+        $ elliott -g openshift-4.14 find-bugs:kernel-clones --move --comment
+    """
+    runtime.initialize(mode="none")
+    cli = FindBugsKernelClonesCli(
+        runtime=runtime,
+        trackers=trackers,
+        issues=issues,
+        move=move,
+        comment=comment,
+        dry_run=dry_run
+    )
+    await cli.run()

--- a/elliottlib/config_model.py
+++ b/elliottlib/config_model.py
@@ -1,0 +1,72 @@
+
+from typing import List
+from pydantic import BaseModel, Field
+
+
+class KernelBugSweepConfig(BaseModel):
+    """ Represents kernel_bug_sweep field in bug.yml
+
+    Example config:
+        kernel_bug_sweep:
+            tracker_jira:
+                project: KMAINT
+                labels:
+                - early-kernel-track
+            bugzilla:
+                target_releases:
+                - 9.2.0
+            target_jira:
+                project: OCPBUGS
+                component: RHCOS
+                version: "{MAJOR}.{MINOR}"
+                target_release: "{MAJOR}.{MINOR}.0"
+                candidate_brew_tag: "rhaos-{MAJOR}.{MINOR}-rhel-9-candidate"
+                prod_brew_tag: "rhaos-{MAJOR}.{MINOR}-rhel-9"
+    """
+    class TrackerJiraConfig(BaseModel):
+        """ tracker_jira field in kernel_bug_sweep config
+        """
+
+        project: str = Field(min_length=1, default="KMAINT")
+        """ Jira project to discover weekly kernel release trackers """
+
+        labels: List[str]
+        """ Jira labels for filtering weekly kernel release trackers """
+
+    class BugzillaConfig(BaseModel):
+        """ bugzilla field in kernel_bug_sweep config
+        """
+
+        target_releases: List[str]
+        """ Target releases of kernel bugs in Bugzilla
+        """
+
+    class TargetJiraConfig(BaseModel):
+        """ target_jira field in kernel_bug_sweep config """
+
+        project: str = Field(min_length=1, default="OCPBUGS")
+        """ Target Jira project to clone kernel bugs into """
+
+        component: str = Field(min_length=1, default="RHCOS")
+        """ Component name to set on cloned kernel bugs """
+
+        version: str = Field(min_length=1)
+        """ Version to set on cloned kernel bugs """
+
+        target_release: str = Field(min_length=1)
+        """ Target Version to set on cloned kernel bugs """
+
+        candidate_brew_tag: str = Field(min_length=1)
+        """ when a kernel build is tagged into this candidate Brew tag, move the bug to MODIFIED """
+
+        prod_brew_tag: str = Field(min_length=1)
+        """ when a kernel build is tagged into this prod Brew tag, move the bug to CLOSED """
+
+    tracker_jira: TrackerJiraConfig
+    """ Config options for weekly kernel release trackers """
+
+    bugzilla: BugzillaConfig
+    """ Config options for source kernel bugs """
+
+    target_jira: TargetJiraConfig
+    """ Config options for cloned Jira bugs """

--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -13,7 +13,7 @@ import click
 import yaml
 
 from elliottlib import brew, constants, gitdata, logutil, util
-from elliottlib.assembly import assembly_basis_event, assembly_group_config
+from elliottlib.assembly import AssemblyTypes, assembly_basis_event, assembly_group_config, assembly_type
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.imagecfg import ImageMetadata
 from elliottlib.model import Missing, Model
@@ -59,6 +59,7 @@ class Runtime(object):
         self.assembly: Optional[str] = 'stream'
         self.assembly_basis_event: Optional[int] = None
         self.releases_config: Optional[Model] = None
+        self.assembly_type = AssemblyTypes.STREAM
 
         for key, val in kwargs.items():
             self.__dict__[key] = val
@@ -218,7 +219,7 @@ class Runtime(object):
         strict_mode = True
         if not self.assembly or self.assembly in ['stream', 'test']:
             strict_mode = False
-
+        self.assembly_type = assembly_type(self.get_releases_config(), self.assembly)
         self.assembly_basis_event = assembly_basis_event(self.get_releases_config(), self.assembly, strict=strict_mode)
         if self.assembly_basis_event:
             if self.brew_event:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "future",
     "koji >= 1.18",
     "semver",
+    "pydantic ~= 1.10.7",
     "pygit2 == 1.10.1",  # https://github.com/libgit2/pygit2/issues/1176
     "python-bugzilla >= 3.2",
     "pyyaml",

--- a/tests/test_find_bugs_kernel_cli.py
+++ b/tests/test_find_bugs_kernel_cli.py
@@ -1,0 +1,355 @@
+from io import StringIO
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import ANY, MagicMock, Mock, patch
+
+import koji
+from bugzilla import Bugzilla
+from bugzilla.bug import Bug
+from jira import JIRA, Issue
+
+from elliottlib.assembly import AssemblyTypes
+from elliottlib.cli.find_bugs_kernel_cli import FindBugsKernelCli
+from elliottlib.config_model import KernelBugSweepConfig
+from elliottlib.runtime import Runtime
+
+
+class TestFindBugsKernelCli(IsolatedAsyncioTestCase):
+    def test_find_kmaint_trackers(self):
+        jira_client = MagicMock(spec=JIRA)
+        issues = [MagicMock(key="FOO-1"), MagicMock(key="FOO-1")]
+        jira_client.search_issues.return_value = issues
+        actual = FindBugsKernelCli._find_kmaint_trackers(jira_client, "FOO", ["label1", "label2"])
+        self.assertEqual(actual, issues)
+        expected_jql = 'project = FOO AND status != Closed AND labels = "label1" AND labels = "label2" ORDER BY created DESC'
+        jira_client.search_issues.assert_called_once_with(expected_jql, maxResults=50)
+
+    def test_get_and_filter_bugs(self):
+        runtime = MagicMock()
+        cli = FindBugsKernelCli(
+            runtime=runtime, trackers=[], clone=True, reconcile=True, comment=True, dry_run=False)
+        bz_client = MagicMock(spec=Bugzilla)
+        bz_client.getbugs.return_value = [
+            MagicMock(spec=Bug, id=1, weburl="irrelevant", cf_zstream_target_release=None),
+            MagicMock(spec=Bug, id=2, weburl="irrelevant", cf_zstream_target_release="8.6.0"),
+            MagicMock(spec=Bug, id=3, weburl="irrelevant", cf_zstream_target_release="9.2.0"),
+            MagicMock(spec=Bug, id=4, weburl="irrelevant", cf_zstream_target_release="8.6.0"),
+        ]
+        bug_ids = [1, 2, 3, 4]
+        bz_target_releases = ["8.6.0"]
+        actual = cli._get_and_filter_bugs(bz_client, bug_ids, bz_target_releases)
+        self.assertEqual([b.id for b in actual], [2, 4])
+        bz_client.getbugs.assert_called_once_with(bug_ids)
+
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._get_and_filter_bugs")
+    def test_find_bugs(self, _get_and_filter_bugs: Mock):
+        runtime = MagicMock()
+        cli = FindBugsKernelCli(
+            runtime=runtime, trackers=[], clone=True, reconcile=True, comment=True, dry_run=False)
+        bz_client = MagicMock(spec=Bugzilla)
+        tracker = MagicMock(spec=Issue, key="TRACKER-1", fields=MagicMock(
+            summary="foo-1.0.1-1.el8_6 and bar-1.0.1-1.el8_6 early delivery via OCP",
+            description="Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+        ))
+        jira_client = MagicMock(spec=JIRA)
+        jira_client.remote_links.return_value = [
+            MagicMock(object=MagicMock(title="bz1", url="http://bugzilla.redhat.com/1")),
+            MagicMock(object=MagicMock(title="fake2", url="https://bugzilla.redhat.com/2")),
+            MagicMock(object=MagicMock(title="fake3", url="https://bugzilla.redhat.com/show_bug.cgi?id=3")),
+            MagicMock(object=MagicMock(title="fake4", url="https://example.com/show_bug.cgi?id=4")),
+        ]
+        expected_bug_ids = [1, 2, 3, 5, 6]
+        _get_and_filter_bugs.return_value = [
+            MagicMock(spec=Bug, id=bug_id, cf_zstream_target_release="8.6.0")
+            for bug_id in expected_bug_ids
+        ]
+        bz_target_releases = ["8.6.0"]
+        actual = cli._find_bugs(jira_client, tracker, bz_client, bz_target_releases)
+        self.assertEqual([b.id for b in actual], expected_bug_ids)
+        _get_and_filter_bugs.assert_called_once_with(bz_client, expected_bug_ids, bz_target_releases)
+
+    def test_clone_bugs1(self):
+        # Test cloning a bug that has not already been cloned
+        runtime = MagicMock()
+        cli = FindBugsKernelCli(
+            runtime=runtime, trackers=[], clone=True, reconcile=True, comment=True, dry_run=False)
+        jira_client = MagicMock(spec=JIRA)
+        bugs = [
+            MagicMock(spec=Bug, id=1, weburl="https://example.com/1",
+                      groups=["private"], priority="high",
+                      summary="fake summary 1", description="fake description 1"),
+        ]
+        conf = KernelBugSweepConfig.TargetJiraConfig(
+            project="TARGET-PROJECT",
+            component="Target Component",
+            version="4.14", target_release="4.14.z",
+            candidate_brew_tag="fake-candidate", prod_brew_tag="fake-prod")
+        jira_client.search_issues.return_value = []
+        tracker = MagicMock(spec=Issue, key="TRACKER-1", fields=MagicMock(
+            summary="foo-1.0.1-1.el8_6 and bar-1.0.1-1.el8_6 early delivery via OCP",
+            description="Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+        ))
+        cli._tracker_map = {
+            bug_id: tracker for bug_id in range(5)
+        }
+        actual = cli._clone_bugs(jira_client, bugs, conf)
+        expected_fields = {
+            "project": {"key": "TARGET-PROJECT"},
+            "components": [{"name": "Target Component"}],
+            "security": {'name': 'Red Hat Employee'},
+            "priority": {"name": "Major"},
+            "summary": "kernel[-rt]: fake summary 1 [rhocp-4.14.z]",
+            "description": "Cloned from https://example.com/1 by OpenShift ART Team:\n----\nfake description 1",
+            "issuetype": {"name": "Bug"},
+            "versions": [{"name": "4.14"}],
+            "customfield_12319940": [{"name": "4.14.z"}],
+            "labels": ["art:cloned-kernel-bug", "art:bz#1", "art:kmaint:TRACKER-1"]
+        }
+        jira_client.create_issue.assert_called_once_with(expected_fields)
+        self.assertEqual([b for b in actual], [1])
+
+    def test_clone_bugs2(self):
+        # Test cloning a bug that has already been cloned
+        runtime = MagicMock()
+        cli = FindBugsKernelCli(
+            runtime=runtime, trackers=[], clone=True, reconcile=True, comment=True, dry_run=False)
+        jira_client = MagicMock(spec=JIRA)
+        bugs = [
+            MagicMock(spec=Bug, id=1, weburl="https://example.com/1",
+                      groups=["private"], priority="high",
+                      summary="fake summary 1", description="fake description 1"),
+        ]
+        conf = KernelBugSweepConfig.TargetJiraConfig(
+            project="TARGET-PROJECT",
+            component="Target Component",
+            version="4.14", target_release="4.14.z",
+            candidate_brew_tag="fake-candidate", prod_brew_tag="fake-prod")
+        found_issues = [
+            MagicMock(spec=Issue, **{"key": "BUG-1", "fields": MagicMock(), "fields.status.name": "New"}),
+        ]
+        jira_client.search_issues.return_value = found_issues
+        tracker = MagicMock(spec=Issue, key="TRACKER-1", fields=MagicMock(
+            summary="foo-1.0.1-1.el8_6 and bar-1.0.1-1.el8_6 early delivery via OCP",
+            description="Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+        ))
+        cli._tracker_map = {
+            bug_id: tracker for bug_id in range(5)
+        }
+        actual = cli._clone_bugs(jira_client, bugs, conf)
+        expected_fields = {
+            "project": {"key": "TARGET-PROJECT"},
+            "components": [{"name": "Target Component"}],
+            "security": {'name': 'Red Hat Employee'},
+            "priority": {"name": "Major"},
+            "summary": "kernel[-rt]: fake summary 1 [rhocp-4.14.z]",
+            "description": "Cloned from https://example.com/1 by OpenShift ART Team:\n----\nfake description 1",
+            "issuetype": {"name": "Bug"},
+            "versions": [{"name": "4.14"}],
+            "customfield_12319940": [{"name": "4.14.z"}],
+            "labels": ["art:cloned-kernel-bug", "art:bz#1", "art:kmaint:TRACKER-1"]
+        }
+        found_issues[0].update.assert_called_once_with(expected_fields)
+        self.assertEqual([b for b in actual], [1])
+
+    def test_print_report(self):
+        report = {
+            "kernel_bugs": [
+                {"id": 2, "summary": "test bug 2", "status": "Verified", "tracker": "TRACKER-1"},
+                {"id": 1, "summary": "test bug 1", "status": "Verified", "tracker": "TRACKER-1"},
+            ],
+            "clones": {
+                1: ["BUG-1"],
+            }
+        }
+        out = StringIO()
+        FindBugsKernelCli._print_report(report, out=out)
+        self.assertEqual(out.getvalue().strip(), """
+TRACKER-1	1	BUG-1	Verified	test bug 1
+TRACKER-1	2	N/A	Verified	test bug 2
+""".strip())
+
+    @patch("elliottlib.brew.get_builds_tags")
+    def test_comment_on_tracker(self, get_builds_tags: Mock):
+        runtime = MagicMock()
+        cli = FindBugsKernelCli(
+            runtime=runtime, trackers=[], clone=True, reconcile=True, comment=True, dry_run=False)
+        jira_client = MagicMock(spec=JIRA)
+        conf = KernelBugSweepConfig.TargetJiraConfig(
+            project="TARGET-PROJECT",
+            component="Target Component",
+            version="4.14", target_release="4.14.z",
+            candidate_brew_tag="fake-candidate", prod_brew_tag="fake-prod")
+        tracker = MagicMock(spec=Issue, key="TRACKER-1", fields=MagicMock(
+            summary="kernel-1.0.1-1.fake and kernel-rt-1.0.1-1.fake early delivery via OCP",
+            description="Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+        ))
+        koji_api = MagicMock(spec=koji.ClientSession)
+        get_builds_tags.return_value = [
+            [{"name": "irrelevant-1"}, {"name": "fake-candidate"}],
+            [{"name": "irrelevant-2"}, {"name": "fake-candidate"}],
+        ]
+        jira_client.comments.return_value = []
+
+        # Test 1: making a comment
+        cli._comment_on_tracker(jira_client, tracker, koji_api, conf)
+        jira_client.add_comment.assert_called_once_with("TRACKER-1", "Build(s) ['kernel-1.0.1-1.fake', 'kernel-rt-1.0.1-1.fake'] was/were already tagged into fake-candidate.")
+
+        # Test 2: not making a comment because a comment has been made
+        jira_client.comments.return_value = [
+            MagicMock(body="irrelevant 1"),
+            MagicMock(body="Build(s) ['kernel-1.0.1-1.fake', 'kernel-rt-1.0.1-1.fake'] was/were already tagged into fake-candidate."),
+            MagicMock(body="irrelevant 2"),
+        ]
+        jira_client.add_comment.reset_mock()
+        cli._comment_on_tracker(jira_client, tracker, koji_api, conf)
+        jira_client.add_comment.assert_not_called()
+
+    def test_new_jira_fields_from_bug(self):
+        bug = MagicMock(spec=Bug, id=12345, cf_zstream_target_release="8.6.0",
+                        weburl="https://example.com/12345",
+                        groups=[], priority="high",
+                        summary="fake summary 12345", description="fake description 12345")
+        tracker = MagicMock(spec=Issue, key="TRACKER-1", fields=MagicMock(
+            summary="kernel-1.0.1-1.fake and kernel-rt-1.0.1-1.fake early delivery via OCP",
+            description="Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+        ))
+        conf = KernelBugSweepConfig.TargetJiraConfig(
+            project="TARGET-PROJECT",
+            component="Target Component",
+            version="4.14", target_release="4.14.z",
+            candidate_brew_tag="fake-candidate", prod_brew_tag="fake-prod")
+
+        # Test 1: new jira fields for a public bug
+        actual = FindBugsKernelCli._new_jira_fields_from_bug(bug, "4.12.z", tracker.key, conf)
+        expected = {
+            "project": {"key": "TARGET-PROJECT"},
+            "components": [{"name": "Target Component"}],
+            "security": None,
+            "priority": {"name": "Major"},
+            "summary": "kernel[-rt]: fake summary 12345 [rhocp-4.12.z]",
+            "description": "Cloned from https://example.com/12345 by OpenShift ART Team:\n----\nfake description 12345",
+            "issuetype": {"name": "Bug"},
+            "versions": [{"name": "4.12"}],
+            "customfield_12319940": [{"name": "4.12.z"}],
+            "labels": ["art:cloned-kernel-bug", "art:bz#12345", "art:kmaint:TRACKER-1"],
+        }
+        self.assertEqual(actual, expected)
+
+        # Test 2: new jira fields for a private bug
+        bug.groups = ["private"]
+        actual = FindBugsKernelCli._new_jira_fields_from_bug(bug, "4.12.z", tracker.key, conf)
+        self.assertEqual(actual["security"], {'name': 'Red Hat Employee'})
+
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._print_report")
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._clone_bugs")
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._comment_on_tracker")
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._find_bugs")
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._find_kmaint_trackers")
+    async def test_run_without_specified_trackers(
+            self, _find_kmaint_trackers: Mock, _find_bugs: Mock, _comment_on_tracker: Mock,
+            _clone_bugs: Mock, _print_report: Mock):
+        runtime = MagicMock(
+            autospec=Runtime, assembly_type=AssemblyTypes.STREAM,
+        )
+        runtime.gitdata.load_data.return_value = MagicMock(
+            data={
+                "kernel_bug_sweep": {
+                    "tracker_jira": {
+                        "project": "KMAINT",
+                        "labels": ["early-kernel-track"],
+                    },
+                    "bugzilla": {
+                        "target_releases": ["9.2.0"],
+                    },
+                    "target_jira": {
+                        "project": "OCPBUGS",
+                        "version": "4.14",
+                        "target_release": "4.14.0",
+                        "candidate_brew_tag": "rhaos-4.14-rhel-9-candidate",
+                        "prod_brew_tag": "rhaos-4.14-rhel-9",
+                    },
+                },
+            }
+        )
+        _find_kmaint_trackers.return_value = [
+            MagicMock(spec=Issue, key="TRACKER-1", fields=MagicMock(
+                summary="kernel-1.0.1-1.fake and kernel-rt-1.0.1-1.fake early delivery via OCP",
+                description="Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+            ))
+        ]
+        _find_bugs.return_value = [
+            MagicMock(spec=Bug, id=10001, cf_zstream_target_release="9.2.0", status="on_qa",
+                      weburl="https://example.com/10001",
+                      groups=[], priority="high",
+                      summary="fake summary 10001", description="fake description 10001"),
+            MagicMock(spec=Bug, id=10002, cf_zstream_target_release="9.2.0", status="on_qa",
+                      weburl="https://example.com/10002",
+                      groups=["private"], priority="high",
+                      summary="fake summary 10002", description="fake description 10002"),
+            MagicMock(spec=Bug, id=10003, cf_zstream_target_release="9.2.0", status="on_qa",
+                      weburl="https://example.com/10003",
+                      groups=["private"], priority="high",
+                      summary="fake summary 10003", description="fake description 10003"),
+        ]
+        cli = FindBugsKernelCli(
+            runtime=runtime, trackers=[], clone=True, reconcile=True, comment=True, dry_run=False)
+        await cli.run()
+        _comment_on_tracker.assert_called_once_with(ANY, _find_kmaint_trackers.return_value[0], ANY, ANY)
+        _clone_bugs.assert_called_once_with(ANY, _find_bugs.return_value, ANY)
+
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._print_report")
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._clone_bugs")
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._comment_on_tracker")
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._find_bugs")
+    @patch("elliottlib.cli.find_bugs_kernel_cli.FindBugsKernelCli._find_kmaint_trackers")
+    async def test_run_with_specified_trackers(
+            self, _find_kmaint_trackers: Mock, _find_bugs: Mock, _comment_on_tracker: Mock,
+            _clone_bugs: Mock, _print_report: Mock):
+        runtime = MagicMock(
+            autospec=Runtime, assembly_type=AssemblyTypes.STREAM,
+        )
+        runtime.gitdata.load_data.return_value = MagicMock(
+            data={
+                "kernel_bug_sweep": {
+                    "tracker_jira": {
+                        "project": "KMAINT",
+                        "labels": ["early-kernel-track"],
+                    },
+                    "bugzilla": {
+                        "target_releases": ["9.2.0"],
+                    },
+                    "target_jira": {
+                        "project": "OCPBUGS",
+                        "version": "4.14",
+                        "target_release": "4.14.0",
+                        "candidate_brew_tag": "rhaos-4.14-rhel-9-candidate",
+                        "prod_brew_tag": "rhaos-4.14-rhel-9",
+                    },
+                },
+            }
+        )
+        jira_client = runtime.bug_trackers.return_value._client
+        jira_client.issue.return_value = \
+            MagicMock(spec=Issue, key="TRACKER-999", fields=MagicMock(
+                summary="kernel-1.0.1-1.fake and kernel-rt-1.0.1-1.fake early delivery via OCP",
+                description="Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+            ))
+        _find_bugs.return_value = [
+            MagicMock(spec=Bug, id=10001, cf_zstream_target_release="9.2.0", status="on_qa",
+                      weburl="https://example.com/10001",
+                      groups=[], priority="high",
+                      summary="fake summary 10001", description="fake description 10001"),
+            MagicMock(spec=Bug, id=10002, cf_zstream_target_release="9.2.0", status="on_qa",
+                      weburl="https://example.com/10002",
+                      groups=["private"], priority="high",
+                      summary="fake summary 10002", description="fake description 10002"),
+            MagicMock(spec=Bug, id=10003, cf_zstream_target_release="9.2.0", status="on_qa",
+                      weburl="https://example.com/10003",
+                      groups=["private"], priority="high",
+                      summary="fake summary 10003", description="fake description 10003"),
+        ]
+        cli = FindBugsKernelCli(
+            runtime=runtime, trackers=["TRACKER-999"], clone=True, reconcile=True, comment=True, dry_run=False)
+        await cli.run()
+        _comment_on_tracker.assert_called_once_with(ANY, jira_client.issue.return_value, ANY, ANY)
+        _clone_bugs.assert_called_once_with(ANY, _find_bugs.return_value, ANY)
+        _find_kmaint_trackers.assert_not_called()

--- a/tests/test_find_bugs_kernel_clones_cli.py
+++ b/tests/test_find_bugs_kernel_clones_cli.py
@@ -1,0 +1,262 @@
+from io import StringIO
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import ANY, MagicMock, Mock, patch
+
+import koji
+from jira import JIRA, Issue
+
+from elliottlib.assembly import AssemblyTypes
+from elliottlib.cli.find_bugs_kernel_clones_cli import FindBugsKernelClonesCli
+from elliottlib.config_model import KernelBugSweepConfig
+
+
+class TestFindBugsKernelClonesCli(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self._config = KernelBugSweepConfig.parse_obj({
+            "tracker_jira": {
+                "project": "KMAINT",
+                "labels": ["early-kernel-track"],
+            },
+            "bugzilla": {
+                "target_releases": ["9.2.0"],
+            },
+            "target_jira": {
+                "project": "OCPBUGS",
+                "component": "RHCOS",
+                "version": "4.14",
+                "target_release": "4.14.0",
+                "candidate_brew_tag": "rhaos-4.14-rhel-9-candidate",
+                "prod_brew_tag": "rhaos-4.14-rhel-9",
+            },
+        })
+
+    def test_get_jira_issues(self):
+        runtime = MagicMock()
+        cli = FindBugsKernelClonesCli(
+            runtime=runtime, trackers=[], issues=[], move=True, comment=True, dry_run=False)
+        jira_client = MagicMock(spec=JIRA)
+        component = MagicMock()
+        component.configure_mock(name="RHCOS")
+        target_release = MagicMock()
+        target_release.configure_mock(name="4.14.0")
+        jira_client.issue.side_effect = lambda key: MagicMock(spec=Issue, **{
+            "key": key,
+            "fields": MagicMock(),
+            "fields.labels": ["art:cloned-kernel-bug"],
+            "fields.project.key": "OCPBUGS",
+            "fields.components": [component],
+            "fields.customfield_12319940": [target_release],
+        })
+        actual = cli._get_jira_issues(jira_client, ["FOO-1", "FOO-2", "FOO-3"], self._config)
+        self.assertEqual([issue.key for issue in actual], ["FOO-1", "FOO-2", "FOO-3"])
+
+    def test_search_for_jira_issues(self):
+        jira_client = MagicMock(spec=JIRA)
+        trackers = ["TRACKER-1", "TRACKER-2"]
+        jira_client.search_issues.return_value = [
+            MagicMock(key="FOO-1"),
+            MagicMock(key="FOO-2"),
+            MagicMock(key="FOO-3"),
+        ]
+        actual = FindBugsKernelClonesCli._search_for_jira_issues(jira_client, trackers, self._config)
+        expected_jql = 'labels = art:cloned-kernel-bug AND project = OCPBUGS AND component = RHCOS AND "Target Version" = "4.14.0" AND (labels = art:kmaint:TRACKER-1 OR labels = art:kmaint:TRACKER-2) order by created DESC'
+        jira_client.search_issues.assert_called_once_with(expected_jql, maxResults=0)
+        self.assertEqual([issue.key for issue in actual], ["FOO-1", "FOO-2", "FOO-3"])
+
+    @patch("elliottlib.cli.find_bugs_kernel_clones_cli.FindBugsKernelClonesCli._move_jira")
+    @patch("elliottlib.brew.get_builds_tags")
+    def test_update_jira_issues(self, get_builds_tags: Mock, _move_jira: Mock):
+        runtime = MagicMock()
+        jira_client = MagicMock(spec=JIRA)
+        jira_client.issue.return_value = MagicMock(spec=Issue, ** {
+            "key": "KMAINT-1",
+            "fields": MagicMock(),
+            "fields.project.key": "KMAINT",
+            "fields.labels": ['early-kernel-track'],
+            "fields.summary": "kernel-1.0.1-1.fake and kernel-rt-1.0.1-1.fake early delivery via OCP",
+            "fields.description": "Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+        })
+        cli = FindBugsKernelClonesCli(
+            runtime=runtime, trackers=[], issues=[], move=True, comment=True, dry_run=False)
+        issues = [
+            MagicMock(spec=Issue, **{
+                "key": "FOO-1", "fields": MagicMock(),
+                "fields.labels": ["art:bz#1", "art:kmaint:KMAINT-1"],
+                "fields.status.name": "New",
+            }),
+            MagicMock(spec=Issue, **{
+                "key": "FOO-2", "fields": MagicMock(),
+                "fields.labels": ["art:bz#2", "art:kmaint:KMAINT-1"],
+                "fields.status.name": "Assigned",
+            }),
+            MagicMock(spec=Issue, **{
+                "key": "FOO-3", "fields": MagicMock(),
+                "fields.labels": ["art:bz#3", "art:kmaint:KMAINT-1"],
+                "fields.status.name": "ON_QA",
+            }),
+        ]
+        koji_api = MagicMock(spec=koji.ClientSession)
+
+        get_builds_tags.return_value = [
+            [{"name": "irrelevant-1"}, {"name": "rhaos-4.14-rhel-9-candidate"}],
+            [{"name": "irrelevant-2"}, {"name": "rhaos-4.14-rhel-9-candidate"}],
+        ]
+        cli._update_jira_issues(jira_client, issues, koji_api, self._config)
+        _move_jira.assert_any_call(jira_client, issues[0], "MODIFIED", ANY)
+        _move_jira.assert_any_call(jira_client, issues[1], "MODIFIED", ANY)
+
+    def test_move_jira(self):
+        runtime = MagicMock()
+        jira_client = MagicMock(spec=JIRA)
+        cli = FindBugsKernelClonesCli(
+            runtime=runtime, trackers=[], issues=[], move=True, comment=True, dry_run=False)
+        comment = "Test message"
+        issue = MagicMock(spec=Issue, **{
+            "key": "FOO-1", "fields": MagicMock(),
+            "fields.labels": ["art:bz#1", "art:kmaint:KMAINT-1"],
+            "fields.status.name": "New",
+        })
+        jira_client.current_user.return_value = "fake-user"
+        cli._move_jira(jira_client, issue, "MODIFIED", comment)
+        jira_client.assign_issue.assert_called_once_with("FOO-1", "fake-user")
+        jira_client.transition_issue.assert_called_once_with("FOO-1", "MODIFIED")
+
+    def test_print_report(self):
+        report = {
+            "jira_issues": [
+                {"key": "FOO-1", "summary": "test bug 1", "status": "Verified"},
+                {"key": "FOO-2", "summary": "test bug 2", "status": "ON_QA"},
+            ]
+        }
+        out = StringIO()
+        FindBugsKernelClonesCli._print_report(report, out=out)
+        self.assertEqual(out.getvalue().strip(), """
+FOO-1	Verified	test bug 1
+FOO-2	ON_QA	test bug 2
+""".strip())
+
+    @patch("elliottlib.cli.find_bugs_kernel_clones_cli.FindBugsKernelClonesCli._print_report")
+    @patch("elliottlib.cli.find_bugs_kernel_clones_cli.FindBugsKernelClonesCli._get_jira_issues")
+    @patch("elliottlib.cli.find_bugs_kernel_clones_cli.FindBugsKernelClonesCli._update_jira_issues")
+    @patch("elliottlib.cli.find_bugs_kernel_clones_cli.FindBugsKernelClonesCli._search_for_jira_issues")
+    async def test_run_without_specified_issues(self, _search_for_jira_issues: Mock, _update_jira_issues: Mock,
+                                                _get_jira_issues: Mock, _print_report: Mock):
+        runtime = MagicMock(assembly_type=AssemblyTypes.STREAM)
+        runtime.gitdata.load_data.return_value = MagicMock(
+            data={
+                "kernel_bug_sweep": {
+                    "tracker_jira": {
+                        "project": "KMAINT",
+                        "labels": ["early-kernel-track"],
+                    },
+                    "bugzilla": {
+                        "target_releases": ["9.2.0"],
+                    },
+                    "target_jira": {
+                        "project": "OCPBUGS",
+                        "version": "4.14",
+                        "target_release": "4.14.0",
+                        "candidate_brew_tag": "rhaos-4.14-rhel-9-candidate",
+                        "prod_brew_tag": "rhaos-4.14-rhel-9",
+                    },
+                },
+            }
+        )
+        jira_client = runtime.bug_trackers.return_value._client
+        found_issues = [
+            MagicMock(spec=Issue, **{
+                "key": "FOO-1", "fields": MagicMock(),
+                "fields.summary": "Fake bug 1",
+                "fields.summary": "Fake bug 1",
+                "fields.labels": ["art:bz#1", "art:kmaint:KMAINT-1"],
+                "fields.status.name": "New",
+            }),
+            MagicMock(spec=Issue, **{
+                "key": "FOO-2", "fields": MagicMock(),
+                "fields.summary": "Fake bug 2",
+                "fields.labels": ["art:bz#2", "art:kmaint:KMAINT-1"],
+                "fields.status.name": "Assigned",
+            }),
+            MagicMock(spec=Issue, **{
+                "key": "FOO-3", "fields": MagicMock(),
+                "fields.summary": "Fake bug 3",
+                "fields.labels": ["art:bz#3", "art:kmaint:KMAINT-1"],
+                "fields.status.name": "ON_QA",
+            }),
+        ]
+        _search_for_jira_issues.return_value = found_issues
+        cli = FindBugsKernelClonesCli(
+            runtime=runtime, trackers=[], issues=[], move=True, comment=True, dry_run=False)
+        await cli.run()
+        _update_jira_issues.assert_called_once_with(jira_client, found_issues, ANY, ANY)
+        expected_report = {
+            'jira_issues': [
+                {'key': 'FOO-1', 'summary': 'Fake bug 1', 'status': 'New'},
+                {'key': 'FOO-2', 'summary': 'Fake bug 2', 'status': 'Assigned'},
+                {'key': 'FOO-3', 'summary': 'Fake bug 3', 'status': 'ON_QA'},
+            ]
+        }
+        _print_report.assert_called_once_with(expected_report, ANY)
+
+    @patch("elliottlib.cli.find_bugs_kernel_clones_cli.FindBugsKernelClonesCli._print_report")
+    @patch("elliottlib.cli.find_bugs_kernel_clones_cli.FindBugsKernelClonesCli._get_jira_issues")
+    @patch("elliottlib.cli.find_bugs_kernel_clones_cli.FindBugsKernelClonesCli._update_jira_issues")
+    @patch("elliottlib.cli.find_bugs_kernel_clones_cli.FindBugsKernelClonesCli._search_for_jira_issues")
+    async def test_run_with_specified_issues(self, _search_for_jira_issues: Mock, _update_jira_issues: Mock,
+                                             _get_jira_issues: Mock, _print_report: Mock):
+        runtime = MagicMock(assembly_type=AssemblyTypes.STREAM)
+        runtime.gitdata.load_data.return_value = MagicMock(
+            data={
+                "kernel_bug_sweep": {
+                    "tracker_jira": {
+                        "project": "KMAINT",
+                        "labels": ["early-kernel-track"],
+                    },
+                    "bugzilla": {
+                        "target_releases": ["9.2.0"],
+                    },
+                    "target_jira": {
+                        "project": "OCPBUGS",
+                        "version": "4.14",
+                        "target_release": "4.14.0",
+                        "candidate_brew_tag": "rhaos-4.14-rhel-9-candidate",
+                        "prod_brew_tag": "rhaos-4.14-rhel-9",
+                    },
+                },
+            }
+        )
+        jira_client = runtime.bug_trackers.return_value._client
+        found_issues = [
+            MagicMock(spec=Issue, **{
+                "key": "FOO-1", "fields": MagicMock(),
+                "fields.summary": "Fake bug 1",
+                "fields.summary": "Fake bug 1",
+                "fields.labels": ["art:bz#1", "art:kmaint:KMAINT-1"],
+                "fields.status.name": "New",
+            }),
+            MagicMock(spec=Issue, **{
+                "key": "FOO-2", "fields": MagicMock(),
+                "fields.summary": "Fake bug 2",
+                "fields.labels": ["art:bz#2", "art:kmaint:KMAINT-1"],
+                "fields.status.name": "Assigned",
+            }),
+            MagicMock(spec=Issue, **{
+                "key": "FOO-3", "fields": MagicMock(),
+                "fields.summary": "Fake bug 3",
+                "fields.labels": ["art:bz#3", "art:kmaint:KMAINT-1"],
+                "fields.status.name": "ON_QA",
+            }),
+        ]
+        _get_jira_issues.return_value = found_issues
+        cli = FindBugsKernelClonesCli(
+            runtime=runtime, trackers=[], issues=["FOO-1", "FOO-2", "FOO-3"], move=True, comment=True, dry_run=False)
+        await cli.run()
+        _update_jira_issues.assert_called_once_with(jira_client, found_issues, ANY, ANY)
+        expected_report = {
+            'jira_issues': [
+                {'key': 'FOO-1', 'summary': 'Fake bug 1', 'status': 'New'},
+                {'key': 'FOO-2', 'summary': 'Fake bug 2', 'status': 'Assigned'},
+                {'key': 'FOO-3', 'summary': 'Fake bug 3', 'status': 'ON_QA'},
+            ]
+        }
+        _print_report.assert_called_once_with(expected_report, ANY)


### PR DESCRIPTION
- `find-bugs:kernel --clone`: scan KMAINT trackers for kernel bugs, clone them into OCP (skip already cloned bugs), and make comments on those KMAINT trackers if builds are tagged.

- `find-bugs:kernel-clones --move`: move cloned kernel bugs to MODIFIED if corresponding builds are tagged into OCP candidate Brew tag (rhaos-x.y-rhel-z-candidate). Those MODIFIED bugs can be swept by ART's normal bug sweep and attached to Errata afterwards.