### PR TITLE
find-bugs:qe - Use local logger instead of click.echo

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -479,13 +479,13 @@ class BugTracker:
         current_status = bug.status
         action = f'changed {bug.id} from {current_status} to {target_status}'
         if current_status == target_status:
-            click.echo(f'{bug.id} is already on {target_status}')
+            logger.info(f'{bug.id} is already on {target_status}')
             return
         elif noop:
-            click.echo(f"Would have {action}")
+            logger.info(f"Would have {action}")
         else:
             self._update_bug_status(bug.id, target_status)
-            click.echo(action)
+            logger.info(action)
 
         comment_lines = []
         if log_comment:
@@ -670,7 +670,7 @@ class JIRABugTracker(BugTracker):
 
     def add_comment(self, bugid: str, comment: str, private: bool, noop=False):
         if noop:
-            click.echo(f"Would have added a private={private} comment to {bugid}")
+            logger.info(f"Would have added a private={private} comment to {bugid}")
             return
         if private:
             self._client.add_comment(bugid, comment, visibility={'type': 'group', 'value': 'Red Hat Employee'})
@@ -718,7 +718,7 @@ class JIRABugTracker(BugTracker):
 
     def _search(self, query, verbose=False) -> List[JIRABug]:
         if verbose:
-            click.echo(query)
+            logger.info(query)
         results = self._client.search_issues(query, maxResults=0)
         return [JIRABug(j) for j in results]
 
@@ -826,7 +826,7 @@ class BugzillaBugTracker(BugTracker):
             return []
         if 'verbose' in kwargs:
             if kwargs.pop('verbose'):
-                click.echo(f'get_bugs called with bugids: {bugids}, permissive: {permissive} and kwargs: {kwargs}')
+                logger.info(f'get_bugs called with bugids: {bugids}, permissive: {permissive} and kwargs: {kwargs}')
         bugs = [BugzillaBug(b) for b in self._client.getbugs(bugids, permissive=permissive, **kwargs)]
         if len(bugs) < len(bugids):
             bugids_not_found = set(bugids) - {b.id for b in bugs}
@@ -853,7 +853,7 @@ class BugzillaBugTracker(BugTracker):
 
     def _search(self, query, verbose=False):
         if verbose:
-            click.echo(query)
+            logger.info(query)
         return [BugzillaBug(b) for b in _perform_query(self._client, query)]
 
     def remove_bugs(self, advisory_obj, bugids: List, noop=False):

--- a/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliottlib/cli/find_bugs_qe_cli.py
@@ -5,7 +5,7 @@ import traceback
 from elliottlib import (Runtime, logutil)
 from elliottlib.cli.common import cli
 from elliottlib.cli.find_bugs_sweep_cli import FindBugsMode
-from elliottlib.util import green_prefix
+
 
 LOGGER = logutil.getLogger(__name__)
 
@@ -39,8 +39,8 @@ def find_bugs_qe_cli(runtime: Runtime, noop):
         try:
             find_bugs_qe(runtime, find_bugs_obj, noop, b)
         except Exception as e:
-            runtime.logger.error(traceback.format_exc())
-            runtime.logger.error(f'exception with {b.type} bug tracker: {e}')
+            LOGGER.error(traceback.format_exc())
+            LOGGER.error(f'exception with {b.type} bug tracker: {e}')
             exit_code = 1
     sys.exit(exit_code)
 
@@ -49,10 +49,10 @@ def find_bugs_qe(runtime, find_bugs_obj, noop, bug_tracker):
     major_version, minor_version = runtime.get_major_minor()
     statuses = sorted(find_bugs_obj.status)
     tr = bug_tracker.target_release()
-    green_prefix(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
+    LOGGER.info(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}")
 
     bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
-    click.echo(f"Found {len(bugs)} bugs: {', '.join(sorted(str(b.id) for b in bugs))}")
+    LOGGER.info(f"Found {len(bugs)} bugs: {', '.join(sorted(str(b.id) for b in bugs))}")
 
     release_comment = (
         "An ART build cycle completed after this fix was made, which usually means it can be"

--- a/tests/test_find_bugs_qe_cli.py
+++ b/tests/test_find_bugs_qe_cli.py
@@ -1,6 +1,4 @@
 import unittest
-import os
-from unittest.mock import patch
 from click.testing import CliRunner
 from elliottlib.cli.common import cli, Runtime
 from elliottlib.cli.find_bugs_qe_cli import FindBugsQE
@@ -37,10 +35,6 @@ class FindBugsQETestCase(unittest.TestCase):
             bz_bug, 'ON_QA', comment=expected_comment, noop=True
         )
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:qe', '--noop'])
-        search_string1 = 'Found 1 bugs: OCPBUGS-123'
-        search_string2 = 'Found 1 bugs: BZ-123'
-        self.assertIn(search_string1, result.output)
-        self.assertIn(search_string2, result.output)
         self.assertEqual(result.exit_code, 0)
 
 


### PR DESCRIPTION
stdout isn't being forwarded from elliott find-bugs:qe in ocp4 job,
so use logger instead.

slack ref: https://redhat-internal.slack.com/archives/GDBRP5YJH/p1686309961426089?thread_ts=1686302994.401709&cid=GDBRP5YJH