### PR TITLE
Add Move builds command

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -68,6 +68,7 @@ from elliottlib.cli.repair_bugs_cli import repair_bugs_cli
 from elliottlib.cli.find_unconsumed_rpms import find_unconsumed_rpms_cli
 from elliottlib.cli.find_bugs_kernel_cli import find_bugs_kernel_cli
 from elliottlib.cli.find_bugs_kernel_clones_cli import find_bugs_kernel_clones_cli
+from elliottlib.cli.move_builds_cli import move_builds_cli
 
 # 3rd party
 import click
@@ -483,6 +484,7 @@ cli.add_command(repair_bugs_cli)
 cli.add_command(find_unconsumed_rpms_cli)
 cli.add_command(find_bugs_kernel_cli)
 cli.add_command(find_bugs_kernel_clones_cli)
+cli.add_command(move_builds_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliottlib/cli/move_builds_cli.py
+++ b/elliottlib/cli/move_builds_cli.py
@@ -1,0 +1,61 @@
+import click
+from errata_tool import ErrataException
+
+import elliottlib
+from elliottlib import Runtime, errata, logutil
+from elliottlib.cli.common import cli
+from elliottlib.util import (ensure_erratatool_auth, red_print)
+
+LOGGER = logutil.getLogger(__name__)
+
+pass_runtime = click.make_pass_decorator(Runtime)
+
+
+@cli.command('move-builds', short_help='Move builds from one advisory to another')
+@click.option(
+    '--from', 'from_advisory', metavar='ADVISORY_ID',
+    type=int, required=True,
+    help='Source advisory to remove attached builds from')
+@click.option(
+    '--to', 'to_advisory', metavar='ADVISORY_ID',
+    type=int, required=True,
+    help='Target advisory to attach builds to')
+@click.option(
+    '--kind', '-k', metavar='KIND', required=True,
+    type=click.Choice(['rpm', 'image']),
+    help='Builds of the given KIND [rpm, image]')
+@click.option(
+    "--noop", "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Don't change anything")
+@pass_runtime
+def move_builds_cli(runtime: Runtime, from_advisory, to_advisory, kind, noop):
+    """
+    Move attached builds from one advisory to another
+
+    $ elliott move-builds --from 123 --to 456 --kind image
+    """
+
+    ensure_erratatool_auth()
+
+    attached_builds = errata.get_brew_builds(from_advisory)
+    build_nvrs = [b.nvr for b in attached_builds]
+
+    if noop:
+        click.echo(f"[DRY-RUN] Would've removed {len(attached_builds)} builds from {from_advisory} and added to {to_advisory}")
+        exit(0)
+
+    try:
+        # remove builds
+        from_erratum = elliottlib.errata.Advisory(errata_id=from_advisory)
+        from_erratum.ensure_state('NEW_FILES')
+        from_erratum.remove_builds(build_nvrs)
+
+        # add builds
+        to_erratum = elliottlib.errata.Advisory(errata_id=to_advisory)
+        to_erratum.ensure_state('NEW_FILES')
+        to_erratum.attach_builds(attached_builds, kind)
+    except ErrataException as e:
+        red_print(e)
+        exit(1)

--- a/elliottlib/cli/move_builds_cli.py
+++ b/elliottlib/cli/move_builds_cli.py
@@ -68,11 +68,9 @@ def move_builds_cli(runtime, from_advisory, to_advisory, kind, only, noop):
 
     # remove builds
     from_erratum = errata.Advisory(errata_id=from_advisory)
-    old_state = from_erratum.errata_state
     from_erratum.ensure_state('NEW_FILES')
     from_erratum.remove_builds(build_nvrs)
-    if old_state != 'NEW_FILES':
-        from_erratum.ensure_state(old_state)
+    # we do not attempt to move advisory to old state since without builds ET doesn't allow advisory to move to QE
 
     # add builds
     to_erratum = errata.Advisory(errata_id=to_advisory)

--- a/elliottlib/cli/move_builds_cli.py
+++ b/elliottlib/cli/move_builds_cli.py
@@ -46,16 +46,18 @@ def move_builds_cli(runtime: Runtime, from_advisory, to_advisory, kind, noop):
         click.echo(f"[DRY-RUN] Would've removed {len(attached_builds)} builds from {from_advisory} and added to {to_advisory}")
         exit(0)
 
-    try:
-        # remove builds
-        from_erratum = elliottlib.errata.Advisory(errata_id=from_advisory)
-        from_erratum.ensure_state('NEW_FILES')
-        from_erratum.remove_builds(build_nvrs)
+    # remove builds
+    from_erratum = elliottlib.errata.Advisory(errata_id=from_advisory)
+    old_state = from_erratum.errata_state
+    from_erratum.ensure_state('NEW_FILES')
+    from_erratum.remove_builds(build_nvrs)
+    if old_state != 'NEW_FILES':
+        from_erratum.ensure_state(old_state)
 
-        # add builds
-        to_erratum = elliottlib.errata.Advisory(errata_id=to_advisory)
-        to_erratum.ensure_state('NEW_FILES')
-        to_erratum.attach_builds(attached_builds, kind)
-    except ErrataException as e:
-        red_print(e)
-        exit(1)
+    # add builds
+    to_erratum = elliottlib.errata.Advisory(errata_id=to_advisory)
+    old_state = to_erratum.errata_state
+    to_erratum.ensure_state('NEW_FILES')
+    to_erratum.attach_builds(attached_builds, kind)
+    if old_state != 'NEW_FILES':
+        to_erratum.ensure_state(old_state)

--- a/elliottlib/cli/remove_bugs_cli.py
+++ b/elliottlib/cli/remove_bugs_cli.py
@@ -1,12 +1,11 @@
 import click
+from errata_tool import ErrataException
+
 from elliottlib import logutil, errata
 from elliottlib.cli.common import cli, use_default_advisory_option, find_default_advisory
 from elliottlib.exceptions import ElliottFatalError
-from elliottlib.util import exit_unauthenticated
 from elliottlib.util import green_prefix
 from elliottlib.bzutil import get_jira_bz_bug_ids, JIRABugTracker, BugzillaBugTracker
-
-from errata_tool import ErrataException
 
 LOGGER = logutil.getLogger(__name__)
 

--- a/elliottlib/cli/verify_attached_operators_cli.py
+++ b/elliottlib/cli/verify_attached_operators_cli.py
@@ -14,7 +14,7 @@ from elliottlib import brew, constants, exectools, errata
 from elliottlib.cli.common import cli, pass_runtime
 from elliottlib.exceptions import ElliottFatalError, BrewBuildException
 from elliottlib.runtime import Runtime
-from elliottlib.util import (exit_unauthenticated, red_print, green_print)
+from elliottlib.util import red_print, green_print
 
 
 @cli.command("verify-attached-operators", short_help="Verify attached operator bundle references are (being) shipped")
@@ -243,10 +243,8 @@ def _missing_references(runtime, bundles, available_shasums, omit_attached):
     if missing_builds_by_advisory:
         print('To fix missing builds in other advisories:')
         for a in missing_builds_by_advisory:
-            # -b build1 -b build2 -b build3
-            builds_args = " ".join([f"-b {b}" for b in missing_builds_by_advisory[a]])
-            print(f'Remove builds: find-builds -k image -a {a} {builds_args} --remove')
-            print('Add builds: Same command but without --remove and -a `<target_advisory>`')
+            builds_args = ",".join([b for b in missing_builds_by_advisory[a]])
+            print(f'elliott move-builds -k image --from {a} --to <target_advisory> --only {builds_args}')
     return missing
 
 


### PR DESCRIPTION
Sometimes we need the ability to simply move builds from one advisory to another
exactly without needing to worry about reanalyzing brew/tags/ET and an extra build slipping in
, like when preparing optional operator advisory at GA time or otherwise in special cases

`elliott move-builds --from 123 --to 456 -k image --noop`

This was tested with this week's release advisories (moving builds from extras -> image)
