### PR TITLE
ART-2892 Find builds rhcos 

### DIFF
--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -639,44 +639,6 @@ def add_jira_bugs_with_retry(advisory: Erratum, bugids: List[str], noop: bool = 
                 raise e
 
 
-def get_rpmdiff_runs(advisory_id, status=None, session=None):
-    """ Get RPMDiff runs for a given advisory.
-    :param advisory_id: advisory number
-    :param status: If set, only returns RPMDiff runs in the status.
-    :param session: requests.Session object.
-    """
-    params = {
-        "filter[active]": "true",
-        "filter[test_type]": "rpmdiff",
-        "filter[errata_id]": advisory_id,
-    }
-    if status:
-        if status not in constants.ET_EXTERNAL_TEST_STATUSES:
-            raise ValueError("{} is not a valid RPMDiff run status.".format(status))
-        params["filter[status]"] = status
-    url = constants.errata_url + "/api/v1/external_tests"
-    if not session:
-        session = requests.Session()
-
-    # This is a paginated API. We need to increment page[number] until an empty array is returned.
-    # https://errata.devel.redhat.com/developer-guide/api-http-api.html#api-pagination
-    page_number = 1
-    while True:
-        params["page[number]"] = page_number
-        resp = session.get(
-            url,
-            params=params,
-            auth=HTTPSPNEGOAuth(),
-        )
-        resp.raise_for_status()
-        data = resp.json()["data"]
-        if not data:
-            break
-        for item in data:
-            yield item
-        page_number += 1
-
-
 def get_image_cdns(advisory_id):
     return errata_xmlrpc.get_advisory_cdn_docker_file_list(advisory_id)
 
@@ -855,3 +817,12 @@ def remove_dependent_advisories(advisory_id):
         if response.status_code != requests.codes.created:
             raise IOError(f'Failed to remove dependent {dependent} from {advisory_id}'
                           f'with code {response.status_code} and error: {response.text}')
+
+
+def get_file_meta(advisory_id):
+    return ErrataConnector()._get(f'/api/v1/erratum/{advisory_id}/filemeta')
+
+
+def put_file_meta(advisory_id, file_meta):
+    return ErrataConnector()._put(f'/api/v1/erratum/{advisory_id}/filemeta',
+                                  data=file_meta)

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -141,36 +141,6 @@ class TestErrata(unittest.TestCase):
 
         self.assertEqual(product_version_map, {'rhaos-4.1-rhel-8-candidate': 'OSE-4.1-RHEL-8'})
 
-    def test_get_rpmdiff_runs(self):
-        advisory_id = 12345
-        responses = [
-            {
-                "data": [
-                    {"id": 1},
-                    {"id": 2},
-                ]
-            },
-            {
-                "data": [
-                    {"id": 3},
-                ]
-            },
-            {
-                "data": []
-            },
-        ]
-        session = mock.MagicMock()
-
-        def mock_response(*args, **kwargs):
-            page_number = kwargs["params"]["page[number]"]
-            resp = mock.MagicMock()
-            resp.json.return_value = responses[page_number - 1]
-            return resp
-
-        session.get.side_effect = mock_response
-        actual = errata.get_rpmdiff_runs(advisory_id, None, session)
-        self.assertEqual(len(list(actual)), 3)
-
 
 class TestAdvisoryImages(unittest.TestCase):
 

--- a/tests/test_find_builds_cli.py
+++ b/tests/test_find_builds_cli.py
@@ -1,7 +1,7 @@
 import unittest
 from elliottlib.cli.find_builds_cli import _filter_out_inviable_builds, _find_shipped_builds
 from elliottlib.brew import Build
-import elliottlib
+from elliottlib import errata as erratalib
 from flexmock import flexmock
 import json
 from unittest import mock
@@ -12,43 +12,23 @@ class TestFindBuildsCli(unittest.TestCase):
     Test elliott find-builds command and internal functions
     """
 
-    def test_attached_errata_failed(self):
-        """
-        Test the internal wrapper function _attached_to_open_erratum_with_correct_product_version
-        attached_to_open_erratum = True, product_version is also the same:
-            _attached_to_open_erratum_with_correct_product_version() should return []
-        """
-        metadata_json_list = []
+    def test_filter_out_inviable_builds_inviable(self):
         metadata = json.loads('''{"release": "4.1", "kind": "rpm", "impetus": "cve"}''')
-        metadata_json_list.append(metadata)
-
-        fake_errata = flexmock(model=elliottlib.errata, get_metadata_comments_json=lambda: 1234)
-        fake_errata.should_receive("get_metadata_comments_json").and_return(metadata_json_list)
+        flexmock(erratalib).should_receive("get_metadata_comments_json").and_return([metadata])
 
         builds = flexmock(Build(nvr="test-1.1.1", product_version="RHEL-7-OSE-4.1"))
         builds.should_receive("all_errata").and_return([{"id": 12345}])
 
-        # expect return empty list []
-        self.assertEqual([], _filter_out_inviable_builds("image", [builds], fake_errata))
+        self.assertEqual([], _filter_out_inviable_builds([builds]))
 
-    def test_attached_errata_succeed(self):
-        """
-        Test the internal wrapper function _attached_to_open_erratum_with_correct_product_version
-        attached_to_open_erratum = True but product_version is not same:
-            _attached_to_open_erratum_with_correct_product_version() should return [Build("test-1.1.1")]
-        """
-        metadata_json_list = []
+    def test_filter_out_inviable_builds_viable(self):
         metadata = json.loads('''{"release": "4.1", "kind": "rpm", "impetus": "cve"}''')
-        metadata_json_list.append(metadata)
-
-        fake_errata = flexmock(model=elliottlib.errata, get_metadata_comments_json=lambda: 1234)
-        fake_errata.should_receive("get_metadata_comments_json").and_return(metadata_json_list)
+        flexmock(erratalib).should_receive("get_metadata_comments_json").and_return([metadata])
 
         builds = flexmock(Build(nvr="test-1.1.1", product_version="RHEL-7-OSE-4.5"))
         builds.should_receive("all_errata").and_return([{"id": 12345}])
 
-        # expect return list with one build
-        self.assertEqual([Build("test-1.1.1")], _filter_out_inviable_builds("image", [builds], fake_errata))
+        self.assertEqual([Build("test-1.1.1")], _filter_out_inviable_builds([builds]))
 
     @mock.patch("elliottlib.brew.get_builds_tags")
     def test_find_shipped_builds(self, get_builds_tags: mock.MagicMock):


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-2892 

Summary
- rhcos x86_64 package - https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=80343 (similar for other arches)
- filemeta API - https://errata.devel.redhat.com/developer-guide/api-http-api.html#advisories
- [filemeta discussion on slack](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1690812515872239)
- filemeta view - https://errata.devel.redhat.com/brew/edit_file_meta/118080

## Test
- `elliott --group openshift-4.13 --assembly 4.13.7 find-builds -k rhcos --use-default-advisory image`
- https://errata.devel.redhat.com/advisory/118080