### PR TITLE
Fix pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["elliottlib"]
+packages = ["elliottlib", "elliottlib.cli"]
 
 [project]
 dynamic = ["version"]


### PR DESCRIPTION
`pip install` elliott has broken because subpackage `elliottlib.cli` was not declared in pyproject.toml. This prevents art-bot from running elliott.

This didn't cause an issue in
aos-cd-jobs because `pip3 install --editable` was used there.