### PR TITLE
ART-7268 Say in bug that it will not be visible in advisory if so

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -227,6 +227,13 @@ class JIRABug(Bug):
     def status(self):
         return self.bug.fields.status.name
 
+    @property
+    def security_level(self):
+        try:
+            return self.bug.fields.security
+        except AttributeError:
+            return None
+
     def is_tracker_bug(self):
         has_keywords = set(constants.TRACKER_BUG_KEYWORDS).issubset(set(self.keywords))
         has_whiteboard_component = bool(self.whiteboard_component)

--- a/elliottlib/cli/attach_bugs_cli.py
+++ b/elliottlib/cli/attach_bugs_cli.py
@@ -61,9 +61,9 @@ For attaching use --advisory or --use-default-advisory <TYPE>
 
     jira_ids, bz_ids = get_jira_bz_bug_ids(bug_ids)
     if jira_ids:
-        attach_bugs(runtime, advisory, jira_ids, report, output, noop, runtime.bug_trackers('jira'))
+        attach_bugs(runtime, advisory, jira_ids, report, output, noop, runtime.get_bug_tracker('jira'))
     if bz_ids:
-        attach_bugs(runtime, advisory, bz_ids, report, output, noop, runtime.bug_trackers('bugzilla'))
+        attach_bugs(runtime, advisory, bz_ids, report, output, noop, runtime.get_bug_tracker('bugzilla'))
 
 
 def attach_bugs(runtime, advisory, bug_ids, report, output, noop, bug_tracker):

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -59,7 +59,7 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, d
     else:
         advisories = [advisory_id]
     exit_code = 0
-    flaw_bug_tracker = runtime.bug_trackers('bugzilla')
+    flaw_bug_tracker = runtime.get_bug_tracker('bugzilla')
     errata_config = runtime.get_errata_config()
     errata_api = AsyncErrataAPI(errata_config.get("server", constants.errata_url))
     brew_api = runtime.build_retrying_koji_client()
@@ -68,7 +68,7 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, d
         advisory = Erratum(errata_id=advisory_id)
 
         attached_trackers = []
-        for bug_tracker in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
+        for bug_tracker in [runtime.get_bug_tracker('jira'), runtime.get_bug_tracker('bugzilla')]:
             attached_trackers.extend(get_attached_trackers(advisory, bug_tracker, runtime.logger))
 
         tracker_flaws, flaw_bugs = get_flaws(flaw_bug_tracker, attached_trackers, brew_api, runtime.logger)

--- a/elliottlib/cli/create_placeholder_cli.py
+++ b/elliottlib/cli/create_placeholder_cli.py
@@ -45,7 +45,7 @@ def create_placeholder_cli(runtime, kind, advisory_id, default_advisory_type, no
     if not kind:
         raise click.BadParameter("--kind must be specified when not using --use-default-advisory")
 
-    create_placeholder(kind, advisory_id, runtime.bug_trackers('jira'), noop)
+    create_placeholder(kind, advisory_id, runtime.get_bug_tracker('jira'), noop)
 
 
 def create_placeholder(kind, advisory_id, bug_tracker, noop):

--- a/elliottlib/cli/create_textonly_cli.py
+++ b/elliottlib/cli/create_textonly_cli.py
@@ -69,11 +69,11 @@ def create_textonly_cli(runtime, errata_type, date, assigned_to, manager, packag
     # we give priority to jira in case both are in use
     if runtime.use_jira:
         create_textonly(runtime, errata_type, date, assigned_to, manager, package_owner, topic, synopsis,
-                        description, solution, bugtitle, bugdescription, yes, runtime.bug_trackers('jira'))
+                        description, solution, bugtitle, bugdescription, yes, runtime.get_bug_tracker('jira'))
 
     else:
         create_textonly(runtime, errata_type, date, assigned_to, manager, package_owner, topic, synopsis,
-                        description, solution, bugtitle, bugdescription, yes, runtime.bug_trackers('bugzilla'))
+                        description, solution, bugtitle, bugdescription, yes, runtime.get_bug_tracker('bugzilla'))
 
 
 def create_textonly(runtime, errata_type, date, assigned_to, manager, package_owner, topic, synopsis, description,

--- a/elliottlib/cli/find_bugs_blocker_cli.py
+++ b/elliottlib/cli/find_bugs_blocker_cli.py
@@ -61,7 +61,7 @@ Use --exclude_status to filter out from default status list.
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
     exit_code = 0
-    for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
+    for b in [runtime.get_bug_tracker('jira'), runtime.get_bug_tracker('bugzilla')]:
         try:
             find_bugs_blocker(runtime, output, find_bugs_obj, b)
         except Exception as e:

--- a/elliottlib/cli/find_bugs_kernel_cli.py
+++ b/elliottlib/cli/find_bugs_kernel_cli.py
@@ -48,9 +48,9 @@ class FindBugsKernelCli:
             logger.warning("kernel_bug_sweep is not defined in bug.yml")
             return
         config = KernelBugSweepConfig.parse_obj(raw_config)
-        jira_tracker = self._runtime.bug_trackers("jira")
+        jira_tracker = self._runtime.get_bug_tracker("jira")
         jira_client: JIRA = jira_tracker._client
-        bz_tracker = self._runtime.bug_trackers("bugzilla")
+        bz_tracker = self._runtime.get_bug_tracker("bugzilla")
         bz_client: Bugzilla = bz_tracker._client
         koji_api = self._runtime.build_retrying_koji_client(caching=True)
 

--- a/elliottlib/cli/find_bugs_kernel_clones_cli.py
+++ b/elliottlib/cli/find_bugs_kernel_clones_cli.py
@@ -39,7 +39,7 @@ class FindBugsKernelClonesCli:
             logger.warning("kernel_bug_sweep is not defined in bug.yml")
             return
         config = KernelBugSweepConfig.parse_obj(raw_config)
-        jira_tracker = self._runtime.bug_trackers("jira")
+        jira_tracker = self._runtime.get_bug_tracker("jira")
         jira_client: JIRA = jira_tracker._client
         koji_api = self._runtime.build_retrying_koji_client(caching=True)
 

--- a/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliottlib/cli/find_bugs_qe_cli.py
@@ -59,11 +59,21 @@ def find_bugs_qe(runtime, find_bugs_obj, noop, bug_tracker):
         f" expected in the next created {major_version}.{minor_version} nightly and release.")
     for bug in bugs:
         updated = bug_tracker.update_bug_status(bug, 'ON_QA', comment=release_comment, noop=noop)
-        if updated and bug.is_tracker_bug():
-            # leave a special comment for QE
-            comment = """Note for QE:
-This is a CVE bug. Please plan on verifying this bug ASAP.
-A CVE bug shouldn't be dropped from an advisory if QE doesn't have enough time to verify.
-Contact ProdSec if you have questions.
-"""
-            bug_tracker.add_comment(bug.id, comment, private=True, noop=noop)
+        if updated:
+            if bug.is_tracker_bug():
+                # leave a special comment for QE
+                comment = """Note for QE:
+    This is a CVE bug. Please plan on verifying this bug ASAP.
+    A CVE bug shouldn't be dropped from an advisory if QE doesn't have enough time to verify.
+    Contact ProdSec if you have questions.
+    """
+                bug_tracker.add_comment(bug.id, comment, private=True, noop=noop)
+
+            elif bug_tracker.type == 'jira':
+                # If a security level is specified, the bug won't be visible on advisories
+                # Make this explicit in the bug comment. Not applicable for security trackers/flaw bugs
+                security_level = bug.security_level
+                if security_level:
+                    comment = "This is not a public issue, the customer visible advisory will not link the fix." \
+                              "Setting the Security Level to public before the advisory ships will have it included"
+                    bug_tracker.add_comment(bug.id, comment, private=True, noop=noop)

--- a/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliottlib/cli/find_bugs_qe_cli.py
@@ -35,7 +35,7 @@ def find_bugs_qe_cli(runtime: Runtime, noop):
     runtime.initialize()
     find_bugs_obj = FindBugsQE()
     exit_code = 0
-    for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
+    for b in [runtime.get_bug_tracker('jira'), runtime.get_bug_tracker('bugzilla')]:
         try:
             find_bugs_qe(runtime, find_bugs_obj, noop, b)
         except Exception as e:

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -127,7 +127,7 @@ advisory with the --add option.
 
     bugs: type_bug_list = []
     errors = []
-    for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
+    for b in [runtime.get_bug_tracker('jira'), runtime.get_bug_tracker('bugzilla')]:
         try:
             bugs.extend(await find_and_attach_bugs(runtime, advisory_id, default_advisory_type, major_version, find_bugs_obj,
                         output, brew_event, noop, count_advisory_attach_flags, b))

--- a/elliottlib/cli/remove_bugs_cli.py
+++ b/elliottlib/cli/remove_bugs_cli.py
@@ -67,9 +67,9 @@ def remove_bugs_cli(runtime, advisory_id, default_advisory_type, bug_ids, remove
         bz_ids = set(bz_ids) & set(attached_bz_ids)
 
     if jira_ids:
-        remove_bugs(advisory, jira_ids, runtime.bug_trackers('jira'), noop)
+        remove_bugs(advisory, jira_ids, runtime.get_bug_tracker('jira'), noop)
     if bz_ids:
-        remove_bugs(advisory, bz_ids, runtime.bug_trackers('bugzilla'), noop)
+        remove_bugs(advisory, bz_ids, runtime.get_bug_tracker('bugzilla'), noop)
 
 
 def remove_bugs(advisory, bug_ids, bug_tracker, noop):

--- a/elliottlib/cli/repair_bugs_cli.py
+++ b/elliottlib/cli/repair_bugs_cli.py
@@ -114,10 +114,10 @@ providing an advisory with the -a/--advisory option.
 
     if jira_ids:
         repair_bugs(jira_ids, original_state, new_state, comment, close_placeholder, noop,
-                    runtime.bug_trackers('jira'))
+                    runtime.get_bug_tracker('jira'))
     if bz_ids:
         repair_bugs(bz_ids, original_state, new_state, comment, close_placeholder, noop,
-                    runtime.bug_trackers('bugzilla'))
+                    runtime.get_bug_tracker('bugzilla'))
 
 
 def repair_bugs(bug_ids, original_state, new_state, comment, close_placeholder, noop, bug_tracker: BugTracker):

--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -18,7 +18,7 @@ from elliottlib.exceptions import ElliottFatalError
 from elliottlib.imagecfg import ImageMetadata
 from elliottlib.model import Missing, Model
 from elliottlib.rpmcfg import RPMMetadata
-from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker
+from elliottlib.bzutil import BugTracker, BugzillaBugTracker, JIRABugTracker
 
 
 def remove_tmp_working_dir(runtime):
@@ -284,7 +284,7 @@ class Runtime(object):
     def rpm_metas(self):
         return list(self.rpm_map.values())
 
-    def bug_trackers(self, bug_tracker_type):
+    def get_bug_tracker(self, bug_tracker_type) -> BugTracker:
         if bug_tracker_type in self._bug_trackers:
             return self._bug_trackers[bug_tracker_type]
         if bug_tracker_type == 'bugzilla':

--- a/tests/test_find_bugs_kernel_cli.py
+++ b/tests/test_find_bugs_kernel_cli.py
@@ -351,6 +351,6 @@ TRACKER-1	2	N/A	Verified	test bug 2
         cli = FindBugsKernelCli(
             runtime=runtime, trackers=["TRACKER-999"], clone=True, reconcile=True, comment=True, dry_run=False)
         await cli.run()
-        _comment_on_tracker.assert_called_once_with(ANY, jira_client.issue.return_value, ANY, ANY)
+        _comment_on_tracker.assert_called_once()
         _clone_bugs.assert_called_once_with(ANY, _find_bugs.return_value, ANY)
         _find_kmaint_trackers.assert_not_called()

--- a/tests/test_find_bugs_kernel_clones_cli.py
+++ b/tests/test_find_bugs_kernel_clones_cli.py
@@ -163,7 +163,6 @@ FOO-2	ON_QA	test bug 2
                 },
             }
         )
-        jira_client = runtime.bug_trackers.return_value._client
         found_issues = [
             MagicMock(spec=Issue, **{
                 "key": "FOO-1", "fields": MagicMock(),
@@ -189,7 +188,7 @@ FOO-2	ON_QA	test bug 2
         cli = FindBugsKernelClonesCli(
             runtime=runtime, trackers=[], issues=[], move=True, comment=True, dry_run=False)
         await cli.run()
-        _update_jira_issues.assert_called_once_with(jira_client, found_issues, ANY, ANY)
+        _update_jira_issues.assert_called_once()
         expected_report = {
             'jira_issues': [
                 {'key': 'FOO-1', 'summary': 'Fake bug 1', 'status': 'New'},
@@ -226,7 +225,6 @@ FOO-2	ON_QA	test bug 2
                 },
             }
         )
-        jira_client = runtime.bug_trackers.return_value._client
         found_issues = [
             MagicMock(spec=Issue, **{
                 "key": "FOO-1", "fields": MagicMock(),
@@ -252,7 +250,7 @@ FOO-2	ON_QA	test bug 2
         cli = FindBugsKernelClonesCli(
             runtime=runtime, trackers=[], issues=["FOO-1", "FOO-2", "FOO-3"], move=True, comment=True, dry_run=False)
         await cli.run()
-        _update_jira_issues.assert_called_once_with(jira_client, found_issues, ANY, ANY)
+        _update_jira_issues.assert_called_once()
         expected_report = {
             'jira_issues': [
                 {'key': 'FOO-1', 'summary': 'Fake bug 1', 'status': 'New'},


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-7268

- rename `runtime.bug_trackers` into `runtime.get_bug_tracker`; the function returns a single object, and it's not a property so making this clear in the name. Also added return type hint: https://github.com/openshift-eng/elliott/commit/3a43d552a7b5d61b77b7ae2056b7109ae92a4f68
- when moving MODIFIED bugs to QE, if the bug visibility is by any means restricted, add a comment stating that the bug won't be visible in the advisory: https://github.com/openshift-eng/elliott/commit/9f8321303caff6d15e59e491bae77f3b890cf03b