### PR TITLE
Use errata-tool from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
     "aiohttp[speedups] >= 3.6",
     "click >= 8.1.3",
-    "errata-tool @ git+https://github.com/red-hat-storage/errata-tool@v1.31.0",
+    "errata-tool ~= 1.31.0",
     "future",
     "koji >= 1.18",
     "semver",


### PR DESCRIPTION
The environment running our github actions doesn't have git. Let's move errata-tool to the PyPI version before making any changes on the github action image.