### PR TITLE
Remove bugzilla search from sweep commands

### DIFF
--- a/elliottlib/cli/find_bugs_blocker_cli.py
+++ b/elliottlib/cli/find_bugs_blocker_cli.py
@@ -60,15 +60,8 @@ Use --exclude_status to filter out from default status list.
     find_bugs_obj = FindBugsBlocker()
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
-    exit_code = 0
-    for b in [runtime.get_bug_tracker('jira'), runtime.get_bug_tracker('bugzilla')]:
-        try:
-            find_bugs_blocker(runtime, output, find_bugs_obj, b)
-        except Exception as e:
-            runtime.logger.error(traceback.format_exc())
-            runtime.logger.error(f'exception with {b.type} bug tracker: {e}')
-            exit_code = 1
-    sys.exit(exit_code)
+
+    find_bugs_blocker(runtime, output, find_bugs_obj, runtime.get_bug_tracker('jira'))
 
 
 def find_bugs_blocker(runtime, output, find_bugs_obj, bug_tracker):

--- a/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliottlib/cli/find_bugs_qe_cli.py
@@ -33,16 +33,7 @@ def find_bugs_qe_cli(runtime: Runtime, noop):
 
 """
     runtime.initialize()
-    find_bugs_obj = FindBugsQE()
-    exit_code = 0
-    for b in [runtime.get_bug_tracker('jira'), runtime.get_bug_tracker('bugzilla')]:
-        try:
-            find_bugs_qe(runtime, find_bugs_obj, noop, b)
-        except Exception as e:
-            LOGGER.error(traceback.format_exc())
-            LOGGER.error(f'exception with {b.type} bug tracker: {e}')
-            exit_code = 1
-    sys.exit(exit_code)
+    find_bugs_qe(runtime, FindBugsQE(), noop, runtime.get_bug_tracker('jira'))
 
 
 def find_bugs_qe(runtime, find_bugs_obj, noop, bug_tracker):

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -125,19 +125,8 @@ advisory with the --add option.
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
 
-    bugs: type_bug_list = []
-    errors = []
-    for b in [runtime.get_bug_tracker('jira'), runtime.get_bug_tracker('bugzilla')]:
-        try:
-            bugs.extend(await find_and_attach_bugs(runtime, advisory_id, default_advisory_type, major_version, find_bugs_obj,
-                        output, brew_event, noop, count_advisory_attach_flags, b))
-        except Exception as e:
-            errors.append(e)
-            logger.error(traceback.format_exc())
-            logger.error(f'exception with {b.type} bug tracker: {e}')
-
-    if errors:
-        raise ElliottFatalError(f"Error finding or attaching bugs: {errors}. See logs for more information.")
+    bugs = await find_and_attach_bugs(runtime, advisory_id, default_advisory_type, major_version, find_bugs_obj,
+                                      output, brew_event, noop, count_advisory_attach_flags, runtime.get_bug_tracker('jira'))
 
     if not bugs:
         logger.info('No bugs found')

--- a/tests/test_find_bugs_blocker_cli.py
+++ b/tests/test_find_bugs_blocker_cli.py
@@ -17,12 +17,6 @@ class FindBugsBlockerTestCase(unittest.TestCase):
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(JIRABugTracker).should_receive("login").and_return(None)
 
-        bz_bug = flexmock(
-            id=1, created_days_ago=lambda: 33,
-            cf_pm_score='score', component='OLM',
-            status='ON_DEV', summary='summary'
-        )
-
         jira_bug = flexmock(
             id='OCPBUGS-1', created_days_ago=lambda: 34,
             cf_pm_score='score', component='OLM',
@@ -30,17 +24,14 @@ class FindBugsBlockerTestCase(unittest.TestCase):
         )
 
         flexmock(JIRABugTracker).should_receive("blocker_search").and_return([jira_bug])
-        flexmock(BugzillaBugTracker).should_receive("blocker_search").and_return([bz_bug])
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:blocker'])
 
-        bz_output = '1             OLM                       ON_DEV       score   33  days   summary'
         jira_output = 'OCPBUGS-1     OLM                       ON_QA        score   34  days   summary'
         if result.exit_code != 0:
             exc_type, exc_value, exc_traceback = result.exc_info
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
             self.fail(t)
         self.assertEqual(result.exit_code, 0)
-        self.assertIn(bz_output, result.output)
         self.assertIn(jira_output, result.output)
 
 

--- a/tests/test_find_bugs_sweep_cli.py
+++ b/tests/test_find_bugs_sweep_cli.py
@@ -218,8 +218,7 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
             self.fail(t)
 
     @patch('elliottlib.bzutil.JIRABugTracker.filter_attached_bugs')
-    @patch('elliottlib.bzutil.BugzillaBugTracker.filter_attached_bugs')
-    def test_find_bugs_sweep_default_advisories(self, bugzilla_filter_mock, jira_filter_mock):
+    def test_find_bugs_sweep_default_advisories(self, jira_filter_mock):
         runner = CliRunner()
         image_bugs = [flexmock(id=1), flexmock(id=2)]
         rpm_bugs = [flexmock(id=3), flexmock(id=4)]
@@ -236,13 +235,6 @@ class FindBugsSweepTestCase(unittest.IsolatedAsyncioTestCase):
         })
         flexmock(Runtime).should_receive("get_default_advisories").and_return({'image': 123, 'rpm': 123, 'extras': 123,
                                                                               'metadata': 123})
-
-        # bz mocks
-        flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
-        flexmock(BugzillaBugTracker).should_receive("login")
-        flexmock(BugzillaBugTracker).should_receive("search").and_return(image_bugs + rpm_bugs + extras_bugs)
-        flexmock(BugzillaBugTracker).should_receive("attach_bugs").times(3).and_return()
-        bugzilla_filter_mock.return_value = []
 
         # jira mocks
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})


### PR DESCRIPTION
Normal OCP bugs are no longer allowed to open in Bugzilla.
Bugzilla is only used for tracking flaw bugs for OCP purposes (which are not part of sweep commands)
So remove searching bugzilla for ocp bugs

Test
- `./elliott --group openshift-4.13 --assembly 4.13.8 find-bugs:sweep --use-default-advisory microshift --noop`