### PR TITLE
[ART-5863] closure for Real Time team when OCP ships a kernel-rt

### DIFF
--- a/elliottlib/early_kernel.py
+++ b/elliottlib/early_kernel.py
@@ -1,7 +1,9 @@
 from typing import Dict, List, Optional, Sequence, TextIO, Tuple, cast
 import re
 import koji
-from jira import Issue
+from errata_tool.build import Build
+from errata_tool import Erratum, ErrataException
+from jira import Issue, JIRA
 from elliottlib.config_model import KernelBugSweepConfig
 from elliottlib import brew
 
@@ -27,3 +29,105 @@ def get_tracker_builds_and_tags(
     candidate = all(candidate_brew_tag in tags for tags in build_tags)
 
     return nvrs, candidate_brew_tag if candidate else None, prod_brew_tag if shipped else None
+
+
+def _advisories_for_builds(nvrs: List[str]) -> List[Erratum]:
+    advisories = {}
+    for nvr in nvrs:
+        try:
+            build = Build(nvr)
+        except ErrataException:
+            continue  # probably build not yet added to an advisory
+        for errata_id in build.all_errata_ids:
+            if errata_id in advisories:
+                continue  # already loaded
+            # TODO: optimize with errata.get_raw_erratum
+            advisory = Erratum(errata_id=errata_id)
+            if advisory.errata_state == "SHIPPED_LIVE":
+                advisories[errata_id] = advisory
+    return list(advisories.values())
+
+
+def _link_tracker_advisories(
+        logger, dry_run: bool, jira_client: JIRA,
+        advisories: List[Erratum], nvrs: List[str], tracker: Issue,
+) -> List[str]:
+    tracker_messages = []
+    links = set(link.raw['object']['url'] for link in jira_client.remote_links(tracker))  # check if we already linked advisories
+    for advisory in advisories:
+        if advisory.url() in links:
+            logger.info(f"Tracker {tracker.id} already links {advisory.url()} ({advisory.synopsis})")
+            continue
+        tracker_messages.append(f"Build(s) {nvrs} shipped in advisory {advisory.url()} with title:\n{advisory.synopsis}")
+        if dry_run:
+            logger.info(f"[DRY RUN] Tracker {tracker.id} would have added link {advisory.url()} ({advisory.errata_name}: {advisory.synopsis})")
+        else:
+            jira_client.add_simple_link(
+                tracker, dict(
+                    url=advisory.url(),
+                    title=f"{advisory.errata_name}: {advisory.synopsis}"))
+    return tracker_messages
+
+
+def process_shipped_tracker(
+        logger, dry_run: bool,
+        jira_client: JIRA, tracker: Issue,
+        nvrs: List[str], shipped_tag: str,
+) -> List[str]:
+    # when NVRs are shipped, ensure the associated tracker is closed with a comment
+    # and a link to any advisory that shipped them
+    logger.info("Build(s) %s shipped (tagged into %s). Looking for advisories...", nvrs, shipped_tag)
+    advisories = _advisories_for_builds(nvrs)
+    if not advisories:
+        raise RuntimeError(f"NVRs {nvrs} tagged into {shipped_tag} but not found in any shipped advisories!")
+    tracker_messages = _link_tracker_advisories(logger, dry_run, jira_client, advisories, nvrs, tracker)
+
+    logger.info("Moving tracker Jira %s to CLOSED...", tracker)
+    current_status: str = tracker.fields.status.name
+    if current_status.lower() != "closed":
+        if tracker_messages:
+            comment_on_tracker(logger, dry_run, jira_client, tracker, tracker_messages)
+        else:
+            logger.warning("Closing Jira %s without adding any messages; prematurely closed?", tracker)
+        move_jira(logger, dry_run, jira_client, tracker, "CLOSED")
+    else:
+        logger.info("No need to move %s because its status is %s", tracker.key, current_status)
+
+
+def move_jira(
+        logger, dry_run: bool,
+        jira_client: JIRA, issue: Issue,
+        new_status: str, comment: str = None,
+):
+    current_status: str = issue.fields.status.name
+    if dry_run:
+        logger.info("[DRY RUN] Would have moved Jira %s from %s to %s", issue.key, current_status, new_status)
+    else:
+        logger.info("Moving %s from %s to %s", issue.key, current_status, new_status)
+        jira_client.assign_issue(issue.key, jira_client.current_user())
+        jira_client.transition_issue(issue.key, new_status)
+        if comment:
+            jira_client.add_comment(issue.key, comment)
+        logger.info("Moved %s from %s to %s", issue.key, current_status, new_status)
+
+
+def comment_on_tracker(
+        logger, dry_run: bool,
+        jira_client: JIRA, tracker: Issue,
+        comments: List[str],
+):
+    # wording NOTE: commenting is intended to avoid duplicates, but this logic may re-comment on old
+    # trackers if the wording changes after previously commented. think long and hard before
+    # changing the wording of any tracker comments.
+    logger.info("Checking if making a comment on tracker %s is needed", tracker.key)
+    previous_comments = jira_client.comments(tracker.key)
+    for comment in comments:
+        if any(previous.body == comment for previous in previous_comments):
+            logger.info("Intended comment was already made on %s", tracker.key)
+            continue
+        logger.info("Making a comment on tracker %s", tracker.key)
+        if dry_run:
+            logger.info("[DRY RUN] Would have left a comment on tracker %s", tracker.key)
+        else:
+            jira_client.add_comment(tracker.key, comment)
+            logger.info("Left a comment on tracker %s", tracker.key)

--- a/elliottlib/early_kernel.py
+++ b/elliottlib/early_kernel.py
@@ -1,0 +1,29 @@
+from typing import Dict, List, Optional, Sequence, TextIO, Tuple, cast
+import re
+import koji
+from jira import Issue
+from elliottlib.config_model import KernelBugSweepConfig
+from elliottlib import brew
+
+
+def get_tracker_builds_and_tags(
+        logger, tracker: Issue,
+        koji_api: koji.ClientSession,
+        config: KernelBugSweepConfig.TargetJiraConfig,
+) -> Tuple[List[str], str, str]:
+    """
+    Determine NVRs (e.g. ["kernel-5.14.0-284.14.1.el9_2"]) from the summary,
+    and whether candidate/base tags have been applied
+    """
+    nvrs = sorted(re.findall(r"(kernel(?:-rt)?-\S+-\S+)", tracker.fields.summary))
+    if not nvrs:
+        raise ValueError(f"Couldn't determine build NVRs for tracker {tracker.id}. Status will not be changed.")
+
+    logger.info("Getting Brew tags for build(s) %s...", nvrs)
+    candidate_brew_tag = config.candidate_brew_tag
+    prod_brew_tag = config.prod_brew_tag
+    build_tags = [set(t["name"] for t in tags) for tags in brew.get_builds_tags(nvrs, koji_api)]
+    shipped = all(prod_brew_tag in tags for tags in build_tags)
+    candidate = all(candidate_brew_tag in tags for tags in build_tags)
+
+    return nvrs, candidate_brew_tag if candidate else None, prod_brew_tag if shipped else None

--- a/tests/test_early_kernel.py
+++ b/tests/test_early_kernel.py
@@ -1,0 +1,137 @@
+from io import StringIO
+from unittest import TestCase
+from unittest.mock import ANY, MagicMock, Mock, patch
+
+import koji
+from jira import JIRA, Issue
+from errata_tool import Erratum
+from errata_tool.build import Build
+
+from elliottlib.config_model import KernelBugSweepConfig
+from elliottlib import early_kernel
+
+
+class TestEarlyKernel(TestCase):
+    @patch("elliottlib.brew.get_builds_tags")
+    def test_get_tracker_builds_and_tags(self, get_builds_tags: Mock):
+        logger = MagicMock()
+        conf = KernelBugSweepConfig.TargetJiraConfig(
+            project="TARGET-PROJECT",
+            component="Target Component",
+            version="4.14", target_release="4.14.z",
+            candidate_brew_tag="fake-candidate", prod_brew_tag="fake-prod")
+        tracker = MagicMock(spec=Issue, key="TRACKER-1", fields=MagicMock(
+            summary="kernel-1.0.1-1.fake and kernel-rt-1.0.1-1.fake early delivery via OCP",
+            description="Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+        ))
+        koji_api = MagicMock(spec=koji.ClientSession)
+        get_builds_tags.return_value = [
+            [{"name": "irrelevant-1"}, {"name": "fake-candidate"}],
+            [{"name": "irrelevant-2"}, {"name": "fake-candidate"}],
+        ]
+
+        nvrs, candidate, shipped = early_kernel.get_tracker_builds_and_tags(logger, tracker, koji_api, conf)
+        self.assertEqual(["kernel-1.0.1-1.fake", "kernel-rt-1.0.1-1.fake"], nvrs)
+        self.assertEqual("fake-candidate", candidate)
+        self.assertFalse(shipped)
+
+    @patch("elliottlib.early_kernel._advisories_for_builds")
+    @patch("elliottlib.early_kernel._link_tracker_advisories")
+    @patch("elliottlib.early_kernel.comment_on_tracker")
+    @patch("elliottlib.early_kernel.move_jira")
+    def test_process_shipped_tracker(self, move_jira: Mock, comment_on_tracker: Mock,
+                                     _link_tracker_advisories: Mock, _advisories_for_builds: Mock):
+        logger = MagicMock()
+        jira_client = MagicMock(spec=JIRA)
+        tracker = MagicMock(spec=Issue, key="TRACKER-1", fields=MagicMock(
+            summary="kernel-1.0.1-1.fake and kernel-rt-1.0.1-1.fake early delivery via OCP",
+            description="Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+            status=Mock(),  # need to set "name" but can't in a mock - set later
+        ))
+        nvrs = ["kernel-1.0.1-1.fake", "kernel-rt-1.0.1-1.fake"]
+        advisory = MagicMock(spec=Erratum)
+        _advisories_for_builds.return_value = [advisory]
+        _link_tracker_advisories.return_value = ["comment"]
+
+        setattr(tracker.fields.status, "name", "CLOSED")
+        early_kernel.process_shipped_tracker(logger, False, jira_client, tracker, nvrs, "tag")
+        comment_on_tracker.assert_not_called()
+        move_jira.assert_not_called()
+
+        setattr(tracker.fields.status, "name", "New")
+        early_kernel.process_shipped_tracker(logger, False, jira_client, tracker, nvrs, "tag")
+        comment_on_tracker.assert_called_once_with(logger, False, jira_client, tracker, ["comment"])
+        move_jira.assert_called_once_with(logger, False, jira_client, tracker, "CLOSED")
+
+    @patch("elliottlib.early_kernel.Erratum")
+    @patch("elliottlib.early_kernel.Build")
+    def test_advisories_for_builds(self, build_clz: Mock, erratum_clz: Mock):
+        build_clz.return_value = MagicMock(spec=Build, all_errata_ids=[42])
+        advisory = erratum_clz.return_value = MagicMock(spec=Erratum, errata_state="SHIPPED_LIVE")
+
+        self.assertEqual([advisory], early_kernel._advisories_for_builds(nvrs=["nvr-1", "nvr-2"]))
+        erratum_clz.assert_called_once_with(errata_id=42)
+
+        advisory.errata_state = "QE"
+        self.assertEqual([], early_kernel._advisories_for_builds(nvrs=["nvr-1", "nvr-2"]))
+
+    def test_link_tracker_advisories(self):
+        tracker = MagicMock(spec=Issue, id=42)
+        advisory = MagicMock(spec=Erratum, errata_name="RHBA-42", synopsis="shipped some stuff")
+        jira_client = MagicMock(spec=JIRA)
+        jira_client.remote_links.return_value = [
+            MagicMock(raw=dict(object=dict(url="http://example.com"))),
+        ]
+
+        # test adding an existing link does not happen
+        advisory.url.return_value = "http://example.com"
+        msgs = early_kernel._link_tracker_advisories(
+            MagicMock(), False, jira_client, [advisory], ["nvrs"], tracker
+        )
+        jira_client.add_simple_link.assert_not_called()
+        self.assertEqual([], msgs)
+
+        # test adding a new link does happen
+        advisory.url.return_value = "http://different.example.com"
+        msgs = early_kernel._link_tracker_advisories(
+            MagicMock(), False, jira_client, [advisory], ["nvrs"], tracker
+        )
+        jira_client.add_simple_link.assert_called_once_with(tracker, ANY)
+        self.assertEqual(1, len(msgs))
+
+    def test_move_jira(self):
+        runtime = MagicMock()
+        jira_client = MagicMock(spec=JIRA)
+        comment = "Test message"
+        issue = MagicMock(spec=Issue, **{
+            "key": "FOO-1", "fields": MagicMock(),
+            "fields.labels": ["art:bz#1", "art:kmaint:KMAINT-1"],
+            "fields.status.name": "New",
+        })
+        jira_client.current_user.return_value = "fake-user"
+        early_kernel.move_jira(runtime.logger(), False, jira_client, issue, "MODIFIED", comment)
+        jira_client.assign_issue.assert_called_once_with("FOO-1", "fake-user")
+        jira_client.transition_issue.assert_called_once_with("FOO-1", "MODIFIED")
+
+    def test_comment_on_tracker(self):
+        logger = MagicMock()
+        jira_client = MagicMock(spec=JIRA)
+        tracker = MagicMock(spec=Issue, key="TRACKER-1", fields=MagicMock(
+            summary="kernel-1.0.1-1.fake and kernel-rt-1.0.1-1.fake early delivery via OCP",
+            description="Fixes bugzilla.redhat.com/show_bug.cgi?id=5 and bz6.",
+        ))
+        comment1, comment2 = "Comment 1", "Comment 2"
+
+        # Test 1: making a comment
+        jira_client.comments.return_value = [MagicMock(body=comment1)]
+        early_kernel.comment_on_tracker(logger, False, jira_client, tracker, [comment2])
+        jira_client.add_comment.assert_called_once_with("TRACKER-1", comment2)
+
+        # Test 2: not making a comment because a comment has been made
+        jira_client.comments.return_value = [
+            MagicMock(body=comment1),
+            MagicMock(body=comment2),
+        ]
+        jira_client.add_comment.reset_mock()
+        early_kernel.comment_on_tracker(logger, False, jira_client, tracker, [comment2, comment1])
+        jira_client.add_comment.assert_not_called()


### PR DESCRIPTION
... although it's really for any early kernel releases. This now follows up on trackers when we ship kernels (previously only cloned bugs were managed to completion). Trackers get links to the advisories that shipped their content, comments on the same, and closure.

I did some dry runs, and then live runs scoped to https://issues.redhat.com/browse/KMAINT-59 (see advisory link and comment there)